### PR TITLE
quick patch for hash consistency.

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -72,7 +72,7 @@ func TestHash(t *testing.T) {
 		fmt.Println("TestHash was not run and autopassed. Currently Poly command line support is not available for windows. See https://github.com/TimothyStiles/poly/issues/16.")
 	} else {
 
-		puc19GbkBlake3Hash := "4031e1971acc8ff1bf0aa4ed623bc58beefc15e043075866a0854d592d80b28b"
+		puc19GbkBlake3Hash := "4b0616d1b3fc632e42d78521deb38b44fba95cca9fde159e01cd567fa996ceb9"
 
 		// testing pipe input
 		command := "cat data/puc19.gbk | poly hash -i gbk"

--- a/hash.go
+++ b/hash.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
+	"strings"
 
 	_ "golang.org/x/crypto/blake2b"
 	_ "golang.org/x/crypto/blake2s"
@@ -106,7 +107,7 @@ func GenericSequenceHash(annotatedSequence AnnotatedSequence, hash crypto.Hash) 
 		annotatedSequence.Sequence.Sequence = RotateSequence(annotatedSequence.Sequence.Sequence)
 	}
 	h := hash.New()
-	io.WriteString(h, annotatedSequence.Sequence.Sequence)
+	io.WriteString(h, strings.ToUpper(annotatedSequence.Sequence.Sequence))
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
@@ -124,7 +125,7 @@ func Blake3SequenceHash(annotatedSequence AnnotatedSequence) string {
 		annotatedSequence.Sequence.Sequence = RotateSequence(annotatedSequence.Sequence.Sequence)
 	}
 
-	b := blake3.Sum256([]byte(annotatedSequence.Sequence.Sequence))
+	b := blake3.Sum256([]byte(strings.ToUpper(annotatedSequence.Sequence.Sequence)))
 	return hex.EncodeToString(b[:])
 }
 

--- a/hash_test.go
+++ b/hash_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestBlake3HashRegression(t *testing.T) {
-	puc19GbkBlake3Hash := "4031e1971acc8ff1bf0aa4ed623bc58beefc15e043075866a0854d592d80b28b"
+	puc19GbkBlake3Hash := "4b0616d1b3fc632e42d78521deb38b44fba95cca9fde159e01cd567fa996ceb9"
 	puc19 := ReadGbk("data/puc19.gbk")
 	if got := puc19.blake3Hash(); got != puc19GbkBlake3Hash {
 		t.Errorf("TestBlake3HashRegression has failed. Blake3 has returned %q, want %q", got, puc19GbkBlake3Hash)


### PR DESCRIPTION
As pointed out in issue #23 there should be a forced default for uppercasing sequences before hashing them.

There should be a default over ride to allow lowercase or no case enforcing but that can come in a later pull request.