### PR TITLE
Add JSON Schema to Poly

### DIFF
--- a/data/polySchema.json
+++ b/data/polySchema.json
@@ -25,7 +25,7 @@
 			"Locus": {"type": "object", "properties": {
 				"Name": {"type": "string"},
 				"SequenceLength": {"type": "string"},
-				"MoleculeType": {"type": "string", "enum": ["DNA","RNA"]},
+				"MoleculeType": {"type": "string", "enum": ["DNA", "genomic DNA", "genomic RNA", "mRNA", "tRNA", "rRNA", "other RNA", "other DNA", "transcribed RNA", "viral cRNA", "unassigned DNA","unassigned RNA"]},
 				"GenBankDivision": {"type": "string"},
 				"ModDate": {"type": "string"},
 				"SequenceCoding": {"type": "string", "enum": ["bp","aa"]},
@@ -69,4 +69,4 @@
 			"Sequence": {"type":"string"}
 		}
 	}
-		}
+}

--- a/data/polySchema.json
+++ b/data/polySchema.json
@@ -1,0 +1,72 @@
+{ 
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"type": "object",
+	"title": "Poly Genbank JSON schema",
+	"description": "The root schema of the Genbank JSON document",
+	"required": ["Meta","Features","Sequence"],
+	"additionalProperties": false,
+	"properties": {
+		"Meta": {"type": "object", "properties": {
+			"Name": {"type": "string"},
+			"GffVersion": {"type": "string"},
+			"RegionStart": {"type": "number"},
+			"RegionEnd": {"type": "number"},
+			"Size": {"type": "number"},
+			"Type": {"type": "string"},
+			"GenbankDivision": {"type": "string"},
+			"Date": {"type": "string"},
+			"Definition": {"type": "string"},
+			"Accession": {"type": "string"},
+			"Version": {"type": "string"},
+			"Keywords": {"type": "string"},
+			"Organism": {"type": "string"},
+			"Source": {"type": "string"},
+			"Origin": {"type": "string"},
+			"Locus": {"type": "object", "properties": {
+				"Name": {"type": "string"},
+				"SequenceLength": {"type": "string"},
+				"MoleculeType": {"type": "string", "enum": ["DNA","RNA"]},
+				"GenBankDivision": {"type": "string"},
+				"ModDate": {"type": "string"},
+				"SequenceCoding": {"type": "string", "enum": ["bp","aa"]},
+				"Circular": {"type": "boolean"}
+			},
+			"References": {"type": "array", "items": {"type": "object", "properties": {
+				"Index": {"type": "string"},
+				"Authors": {"type": "string"},
+				"Title": {"type": "string"},
+				"Journal": {"type": "string"},
+				"PubMed": {"type": "string"},
+				"Remark": {"type": "string"},
+				"Range": {"type": "string"}
+			}}},
+			"Primaries": {"type": "string"}
+		}}},
+		"Features": {"type": "array", "items": {"type": "object", "properties": {
+			"Name": {"type": "string"},
+			"Source": {"type": "string"},
+			"Type": {"type": "string"},
+			"Start": {"type": "number"},
+			"End": {"type": "number"},
+			"Complement": {"type": "boolean"},
+			"FivePrimePartial": {"type": "boolean"},
+			"ThreePrimePartial": {"type": "boolean"},
+			"Score": {"type": "string"},
+			"Strand": {"type": "string"},
+			"Phase": {"type": "string"},
+			"Attributes": {"type": "object", "properties": {
+				"label": {"type": "string"},
+				"mol_type": {"type": "string"},
+				"organism": {"type": "string"}
+			},
+			"Location": {"type": "string"}
+			}
+		}}},
+		"Sequence": {
+			"Description": {"type": "string"},
+			"Hash": {"type": "string"},
+			"HashFunction": {"type": "string", "enum": ["MD5","SHA1","SHA224","SHA256","SHA384","SHA512","MD5SHA1","RIPEMD160","SHA3_224","SHA3_256","SHA3_512","SHA512_224","SHA512_256","BLAKE2s_256","BLAKE2b_256","BLAKE2b_384","BLAKE2b_512","BLAKE3"]},
+			"Sequence": {"type":"string"}
+		}
+	}
+		}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/sergi/go-diff v1.1.0
 	github.com/urfave/cli/v2 v2.2.0
+	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
 	lukechampine.com/blake3 v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -24,10 +24,17 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 h1:vEg9joUBmeBcK9iSJftGNf3coIG4HqZElCPehJsfAYM=
 golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/io_test.go
+++ b/io_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pmezard/go-difflib/difflib"
+	"github.com/xeipuuv/gojsonschema"
 )
 
 /******************************************************************************
@@ -149,6 +150,26 @@ func TestJSONIO(t *testing.T) {
 	if diff := cmp.Diff(testSequence, readTestSequence); diff != "" {
 		t.Errorf(" mismatch (-want +got):\n%s", diff)
 	}
+}
+
+func TestJSONSchema(t *testing.T) {
+	testSequence := ReadGbk("data/bsub.gbk")
+	WriteJSON(testSequence, "data/test.json")
+	schema := gojsonschema.NewReferenceLoader("file://data/polySchema.json")
+	document := gojsonschema.NewReferenceLoader("file://data/test.json")
+	result, err := gojsonschema.Validate(schema, document)
+
+	//Clean up test data
+	os.Remove("data/test.json")
+
+	if err != nil {
+		t.Errorf("Failed to parse schema or document")
+	}
+
+	if !(result.Valid()) {
+		t.Errorf("Document not valid : \n %s", result.Errors()[0].Description())
+	}
+
 }
 
 /******************************************************************************


### PR DESCRIPTION
A JSON Schema is a cross-language validation format. If we had a JSON Schema for Poly's Genbank output, in the future it would be much easier to get adoption of our JSON-gene format, since anyone can test their Genbank parser + JSON output + Genbank writer against this schema format. In addition, it would give guarantees to downstream applications consuming the JSON, which is nice for application developers. 

This pull request contains my first pass at a JSON Schema, and a test function in `io_test.go` to validate that the schema validates output JSON. The JSON Schema will need improvements over time, but this gives a decent first pass and something to iterate on. 