### PR TITLE
Refactored parsing functions to accept bytes instead of string

### DIFF
--- a/data/sample.json
+++ b/data/sample.json
@@ -1,0 +1,193 @@
+{
+ "Meta": {
+  "Name": "",
+  "GffVersion": "",
+  "RegionStart": 0,
+  "RegionEnd": 0,
+  "Size": 0,
+  "Type": "",
+  "GenbankDivision": "",
+  "Date": "",
+  "Definition": "Saccharomyces cerevisiae TCP1-beta gene, partial cds, and Axl2p (AXL2) and Rev7p (REV7) genes, complete cds.",
+  "Accession": "U49845",
+  "Version": "U49845.1  GI:1293613",
+  "Keywords": ".",
+  "Organism": "Saccharomyces cerevisiae Eukaryota; Fungi; Ascomycota; Saccharomycotina; Saccharomycetes; Saccharomycetales; Saccharomycetaceae; Saccharomyces.",
+  "Source": "Saccharomyces cerevisiae (baker's yeast)",
+  "Origin": "",
+  "Locus": {
+   "Name": "SCU49845",
+   "SequenceLength": "5028",
+   "MoleculeType": "DNA",
+   "GenBankDivision": "PLN",
+   "ModDate": "21-JUN-1999",
+   "SequenceCoding": "bp",
+   "Circular": false
+  },
+  "References": [
+   {
+    "Index": "1",
+    "Authors": "Torpey,L.E., Gibbs,P.E., Nelson,J. and Lawrence,C.W.",
+    "Title": "Cloning and sequence of REV7, a gene whose function is required for DNA damage-induced mutagenesis in Saccharomyces cerevisiae",
+    "Journal": "Yeast 10 (11), 1503-1509 (1994)",
+    "PubMed": "7871890",
+    "Remark": "",
+    "Range": "(bases 1 to 5028)"
+   },
+   {
+    "Index": "2",
+    "Authors": "Roemer,T., Madden,K., Chang,J. and Snyder,M.",
+    "Title": "Selection of axial growth sites in yeast requires Axl2p, a novel plasma membrane glycoprotein",
+    "Journal": "Genes Dev. 10 (7), 777-793 (1996)",
+    "PubMed": "8846915",
+    "Remark": "",
+    "Range": "(bases 1 to 5028)"
+   },
+   {
+    "Index": "3",
+    "Authors": "Roemer,T.",
+    "Title": "Direct Submission",
+    "Journal": "Submitted (22-FEB-1996) Terry Roemer, Biology, Yale University, New Haven, CT, USA",
+    "PubMed": "",
+    "Remark": "",
+    "Range": "(bases 1 to 5028)"
+   }
+  ],
+  "Primaries": null
+ },
+ "Features": [
+  {
+   "Name": "",
+   "Source": "",
+   "Type": "source",
+   "Start": 1,
+   "End": 5028,
+   "Complement": false,
+   "FivePrimePartial": false,
+   "ThreePrimePartial": false,
+   "Score": "",
+   "Strand": "",
+   "Phase": "",
+   "Attributes": {
+    "chromosome": "IX",
+    "db_xref": "taxon:4932",
+    "map": "9",
+    "organism": "Saccharomyces cerevisiae"
+   },
+   "Location": "1..5028",
+   "Sequence": ""
+  },
+  {
+   "Name": "",
+   "Source": "",
+   "Type": "CDS",
+   "Start": 1,
+   "End": 206,
+   "Complement": false,
+   "FivePrimePartial": true,
+   "ThreePrimePartial": false,
+   "Score": "",
+   "Strand": "",
+   "Phase": "",
+   "Attributes": {
+    "codon_start": "3",
+    "db_xref": "GI:1293614",
+    "product": "TCP1-beta",
+    "protein_id": "AAA98665.1",
+    "translation": "SSIYNGISTSGLDLNNGTIADMRQLGIVESYKLKRAVVSSASEAAEVLLRVDNIIRARPRTANRQHM"
+   },
+   "Location": "\u003c1..206",
+   "Sequence": ""
+  },
+  {
+   "Name": "",
+   "Source": "",
+   "Type": "gene",
+   "Start": 687,
+   "End": 3158,
+   "Complement": false,
+   "FivePrimePartial": false,
+   "ThreePrimePartial": false,
+   "Score": "",
+   "Strand": "",
+   "Phase": "",
+   "Attributes": {
+    "gene": "AXL2"
+   },
+   "Location": "687..3158",
+   "Sequence": ""
+  },
+  {
+   "Name": "",
+   "Source": "",
+   "Type": "CDS",
+   "Start": 687,
+   "End": 3158,
+   "Complement": false,
+   "FivePrimePartial": false,
+   "ThreePrimePartial": false,
+   "Score": "",
+   "Strand": "",
+   "Phase": "",
+   "Attributes": {
+    "codon_start": "1",
+    "db_xref": "GI:1293615",
+    "function": "required for axial budding pattern of S.cerevisiae",
+    "gene": "AXL2",
+    "note": "plasma membrane glycoprotein",
+    "product": "Axl2p",
+    "protein_id": "AAA98666.1",
+    "translation": "MTQLQISLLLTATISLLHLVVATPYEAYPIGKQYPPVARVNESFTFQISNDTYKSSVDKTAQITYNCFDLPSWLSFDSSSRTFSGEPSSDLLSDANTTLYFNVILEGTDSADSTSLNNTYQFVVTNRPSISLSSDFNLLALLKNYGYTNGKNALKLDPNEVFNVTFDRSMFTNEESIVSYYGRSQLYNAPLPNWLFFDSGELKFTGTAPVINSAIAPETSYSFVIIATDIEGFSAVEVEFELVIGAHQLTTSIQNSLIINVTDTGNVSYDLPLNYVYLDDDPISSDKLGSINLLDAPDWVALDNATISGSVPDELLGKNSNPANFSVSIYDTYGDVIYFNFEVVSTTDLFAISSLPNINATRGEWFSYYFLPSQFTDYVNTNVSLEFTNSSQDHDWVKFQSSNLTLAGEVPKNFDKLSLGLKANQGSQSQELYFNIIGMDSKITHSNHSANATSTRSSHHSTSTSSYTSSTYTAKISSTSAAATSSAPAALPAANKTSSHNKKAVAIACGVAIPLGVILVALICFLIFWRRRRENPDDENLPHAISGPDLNNPANKPNQENATPLNNPFDDDASSYDDTSIARRLAALNTLKLDNHSATESDISSVDEKRDSLSGMNTYNDQFQSQSKEELLAKPPVQPPESPFFDPQNRSSSVYMDSEPAVNKSWRYTGNLSPVSDIVRDSYGSQKTVDTEKLFDLEAPEKEKRTSRDVTMSSLDPWNSNISPSPVRKSVTPSPYNVTKHRNRHLQNIQDSQSGKNGITPTTMSTSSSDDFVPVKDGENFCWVHSMEPDRRPSKKRLVDFSNKSNVNVGQVKDIHGRIPEML"
+   },
+   "Location": "687..3158",
+   "Sequence": ""
+  },
+  {
+   "Name": "",
+   "Source": "",
+   "Type": "gene",
+   "Start": 3300,
+   "End": 4037,
+   "Complement": true,
+   "FivePrimePartial": false,
+   "ThreePrimePartial": false,
+   "Score": "",
+   "Strand": "",
+   "Phase": "",
+   "Attributes": {
+    "gene": "REV7"
+   },
+   "Location": "complement(3300..4037)",
+   "Sequence": ""
+  },
+  {
+   "Name": "",
+   "Source": "",
+   "Type": "CDS",
+   "Start": 3300,
+   "End": 4037,
+   "Complement": true,
+   "FivePrimePartial": false,
+   "ThreePrimePartial": false,
+   "Score": "",
+   "Strand": "",
+   "Phase": "",
+   "Attributes": {
+    "codon_start": "1",
+    "db_xref": "GI:1293616",
+    "gene": "REV7",
+    "product": "Rev7p",
+    "protein_id": "AAA98667.1",
+    "translation": "MNRWVEKWLRVYLKCYINLILFYRNVYPPQSFDYTTYQSFNLPQFVPINRHPALIDYIEELILDVLSKLTHVYRFSICIINKKNDLCIEKYVLDFSELQHVDKDDQIITETEVFDEFRSSLNSLIMHLEKLPKVNDDTITFEAVINAIELELGHKLDRNRRVDSLEEKAEIERDSNWVKCQEDENLPDNNGFQPPKIKLTSLVGSDVGPLIIHQFSEKLISGDDKILNGVYSQYEEGESIFGSLF"
+   },
+   "Location": "complement(3300..4037)",
+   "Sequence": ""
+  }
+ ],
+ "Sequence": {
+  "Description": "",
+  "Hash": "",
+  "HashFunction": "",
+  "Sequence": "gatcctccatatacaacggtatctccacctcaggtttagatctcaacaacggaaccattgccgacatgagacagttaggtatcgtcgagagttacaagctaaaacgagcagtagtcagctctgcatctgaagccgctgaagttctactaagggtggataacatcatccgtgcaagaccaagaaccgccaatagacaacatatgtaacatatttaggatatacctcgaaaataataaaccgccacactgtcattattataattagaaacagaacgcaaaaattatccactatataattcaaagacgcgaaaaaaaaagaacaacgcgtcatagaacttttggcaattcgcgtcacaaataaattttggcaacttatgtttcctcttcgagcagtactcgagccctgtctcaagaatgtaataatacccatcgtaggtatggttaaagatagcatctccacaacctcaaagctccttgccgagagtcgccctcctttgtcgagtaattttcacttttcatatgagaacttattttcttattctttactctcacatcctgtagtgattgacactgcaacagccaccatcactagaagaacagaacaattacttaatagaaaaattatatcttcctcgaaacgatttcctgcttccaacatctacgtatatcaagaagcattcacttaccatgacacagcttcagatttcattattgctgacagctactatatcactactccatctagtagtggccacgccctatgaggcatatcctatcggaaaacaataccccccagtggcaagagtcaatgaatcgtttacatttcaaatttccaatgatacctataaatcgtctgtagacaagacagctcaaataacatacaattgcttcgacttaccgagctggctttcgtttgactctagttctagaacgttctcaggtgaaccttcttctgacttactatctgatgcgaacaccacgttgtatttcaatgtaatactcgagggtacggactctgccgacagcacgtctttgaacaatacataccaatttgttgttacaaaccgtccatccatctcgctatcgtcagatttcaatctattggcgttgttaaaaaactatggttatactaacggcaaaaacgctctgaaactagatcctaatgaagtcttcaacgtgacttttgaccgttcaatgttcactaacgaagaatccattgtgtcgtattacggacgttctcagttgtataatgcgccgttacccaattggctgttcttcgattctggcgagttgaagtttactgggacggcaccggtgataaactcggcgattgctccagaaacaagctacagttttgtcatcatcgctacagacattgaaggattttctgccgttgaggtagaattcgaattagtcatcggggctcaccagttaactacctctattcaaaatagtttgataatcaacgttactgacacaggtaacgtttcatatgacttacctctaaactatgtttatctcgatgacgatcctatttcttctgataaattgggttctataaacttattggatgctccagactgggtggcattagataatgctaccatttccgggtctgtcccagatgaattactcggtaagaactccaatcctgccaatttttctgtgtccatttatgatacttatggtgatgtgatttatttcaacttcgaagttgtctccacaacggatttgtttgccattagttctcttcccaatattaacgctacaaggggtgaatggttctcctactattttttgccttctcagtttacagactacgtgaatacaaacgtttcattagagtttactaattcaagccaagaccatgactgggtgaaattccaatcatctaatttaacattagctggagaagtgcccaagaatttcgacaagctttcattaggtttgaaagcgaaccaaggttcacaatctcaagagctatattttaacatcattggcatggattcaaagataactcactcaaaccacagtgcgaatgcaacgtccacaagaagttctcaccactccacctcaacaagttcttacacatcttctacttacactgcaaaaatttcttctacctccgctgctgctacttcttctgctccagcagcgctgccagcagccaataaaacttcatctcacaataaaaaagcagtagcaattgcgtgcggtgttgctatcccattaggcgttatcctagtagctctcatttgcttcctaatattctggagacgcagaagggaaaatccagacgatgaaaacttaccgcatgctattagtggacctgatttgaataatcctgcaaataaaccaaatcaagaaaacgctacacctttgaacaacccctttgatgatgatgcttcctcgtacgatgatacttcaatagcaagaagattggctgctttgaacactttgaaattggataaccactctgccactgaatctgatatttccagcgtggatgaaaagagagattctctatcaggtatgaatacatacaatgatcagttccaatcccaaagtaaagaagaattattagcaaaacccccagtacagcctccagagagcccgttctttgacccacagaataggtcttcttctgtgtatatggatagtgaaccagcagtaaataaatcctggcgatatactggcaacctgtcaccagtctctgatattgtcagagacagttacggatcacaaaaaactgttgatacagaaaaacttttcgatttagaagcaccagagaaggaaaaacgtacgtcaagggatgtcactatgtcttcactggacccttggaacagcaatattagcccttctcccgtaagaaaatcagtaacaccatcaccatataacgtaacgaagcatcgtaaccgccacttacaaaatattcaagactctcaaagcggtaaaaacggaatcactcccacaacaatgtcaacttcatcttctgacgattttgttccggttaaagatggtgaaaatttttgctgggtccatagcatggaaccagacagaagaccaagtaagaaaaggttagtagatttttcaaataagagtaatgtcaatgttggtcaagttaaggacattcacggacgcatcccagaaatgctgtgattatacgcaacgatattttgcttaattttattttcctgttttattttttattagtggtttacagataccctatattttatttagtttttatacttagagacatttaattttaattccattcttcaaatttcatttttgcacttaaaacaaagatccaaaaatgctctcgccctcttcatattgagaatacactccattcaaaattttgtcgtcaccgctgattaatttttcactaaactgatgaataatcaaaggccccacgtcagaaccgactaaagaagtgagttttattttaggaggttgaaaaccattattgtctggtaaattttcatcttcttgacatttaacccagtttgaatccctttcaatttctgctttttcctccaaactatcgaccctcctgtttctgtccaacttatgtcctagttccaattcgatcgcattaataactgcttcaaatgttattgtgtcatcgttgactttaggtaatttctccaaatgcataatcaaactatttaaggaagatcggaattcgtcgaacacttcagtttccgtaatgatctgatcgtctttatccacatgttgtaattcactaaaatctaaaacgtatttttcaatgcataaatcgttctttttattaataatgcagatggaaaatctgtaaacgtgcgttaatttagaaagaacatccagtataagttcttctatatagtcaattaaagcaggatgcctattaatgggaacgaactgcggcaagttgaatgactggtaagtagtgtagtcgaatgactgaggtgggtatacatttctataaaataaaatcaaattaatgtagcattttaagtataccctcagccacttctctacccatctattcataaagctgacgcaacgattactattttttttttcttcttggatctcagtcgtcgcaaaaacgtataccttctttttccgaccttttttttagctttctggaaaagtttatattagttaaacagggtctagtcttagtgtgaaagctagtggtttcgattgactgatattaagaaagtggaaattaaattagtagtgtagacgtatatgcatatgtatttctcgcctgtttatgtttctacgtacttttgatttatagcaaggggaaaagaaatacatactattttttggtaaaggtgaaagcataatgtaaaagctagaataaaatggacgaaataaagagaggcttagttcatcttttttccaaaaagcacccaatgataataactaaaatgaaaaggatttgccatctgtcagcaacatcagttgtgtgagcaataataaaatcatcacctccgttgcctttagcgcgtttgtcgtttgtatcttccgtaattttagtcttatcaatgggaatcataaattttccaatgaattagcaatttcgtccaattctttttgagcttcttcatatttgctttggaattcttcgcacttcttttcccattcatctctttcttcttccaaagcaacgatccttctacccatttgctcagagttcaaatcggcctctttcagtttatccattgcttccttcagtttggcttcactgtcttctagctgttgttctagatcctggtttttcttggtgtagttctcattattagatctcaagttattggagtcttcagccaattgctttgtatcagacaattgactctctaacttctccacttcactgtcgagttgctcgtttttagcggacaaagatttaatctcgttttctttttcagtgttagattgctctaattctttgagctgttctctcagctcctcatatttttcttgccatgactcagattctaattttaagctattcaatttctctttgatc"
+ }
+}

--- a/io.go
+++ b/io.go
@@ -139,7 +139,9 @@ GFF specific IO related things begin here.
 ******************************************************************************/
 
 // ParseGff Takes in a string representing a gffv3 file and parses it into an Sequence object.
-func ParseGff(gff string) Sequence {
+func ParseGff(gffBytes []byte) Sequence {
+
+	gff := string(gffBytes)
 	sequence := Sequence{}
 
 	lines := strings.Split(gff, "\n")
@@ -327,7 +329,7 @@ func ReadGff(path string) Sequence {
 	if err != nil {
 		// return 0, fmt.Errorf("Failed to open file %s for unpack: %s", gzFilePath, err)
 	} else {
-		sequence = ParseGff(string(file))
+		sequence = ParseGff(file)
 	}
 	return sequence
 }
@@ -392,8 +394,8 @@ FASTA specific IO related things begin here.
 ******************************************************************************/
 
 // ParseFASTA parses a Sequence struct from a FASTA file and adds appropriate pointers to the structs.
-func ParseFASTA(fasta string) Sequence {
-
+func ParseFASTA(fastaBytes []byte) Sequence {
+	fasta := string(fastaBytes)
 	var sequence Sequence
 	var feature Feature
 	var features []Feature
@@ -500,8 +502,8 @@ func ReadFASTA(path string) Sequence {
 	if err != nil {
 		// return 0, fmt.Errorf("Failed to open file %s for unpack: %s", gzFilePath, err)
 	}
-	annotatedSequenceArray := ParseFASTA(string(file))
-	return annotatedSequenceArray
+	sequence := ParseFASTA(file)
+	return sequence
 }
 
 // WriteFASTA writes a Sequence struct out to FASTA.
@@ -522,8 +524,9 @@ GBK specific IO related things begin here.
 ******************************************************************************/
 
 // ParseGbk takes in a string representing a gbk/gb/genbank file and parses it into an Sequence object.
-func ParseGbk(gbk string) Sequence {
+func ParseGbk(gbkBytes []byte) Sequence {
 
+	gbk := string(gbkBytes)
 	lines := strings.Split(gbk, "\n")
 
 	// Create meta struct
@@ -716,8 +719,7 @@ func ReadGbk(path string) Sequence {
 	if err != nil {
 		// return 0, fmt.Errorf("Failed to open file %s for unpack: %s", gzFilePath, err)
 	} else {
-		gbkString := string(file)
-		sequence = ParseGbk(gbkString)
+		sequence = ParseGbk(file)
 
 	}
 	return sequence

--- a/io_test.go
+++ b/io_test.go
@@ -60,6 +60,8 @@ func ExampleWriteGff() {
 	WriteGff(sequence, "data/test.gff")
 	testSequence := ReadGff("data/test.gff")
 
+	os.Remove("data/test.gff")
+
 	fmt.Println(testSequence.Meta.Name)
 	// Output: U00096.3
 }
@@ -151,6 +153,8 @@ func ExampleWriteGbk() {
 	sequence := ReadGbk("data/puc19.gbk")
 	WriteGbk(sequence, "data/test.gbk")
 	testSequence := ReadGbk("data/test.gbk")
+
+	os.Remove("data/test.gbk")
 
 	fmt.Println(testSequence.Meta.Locus.ModificationDate)
 	// Output: 22-OCT-2019
@@ -270,6 +274,32 @@ Gbk/gb/genbank related benchmarks end here.
 JSON related tests begin here.
 
 ******************************************************************************/
+
+func ExampleReadJSON() {
+	sequence := ReadJSON("data/sample.json")
+
+	fmt.Println(sequence.Meta.Source)
+	//output: Saccharomyces cerevisiae (baker's yeast)
+}
+
+func ExampleParseJSON() {
+	file, _ := ioutil.ReadFile("data/sample.json")
+	sequence := ParseJSON(file)
+
+	fmt.Println(sequence.Meta.Source)
+	//output: Saccharomyces cerevisiae (baker's yeast)
+}
+
+func ExampleWriteJSON() {
+	sequence := ReadJSON("data/sample.json")
+	WriteJSON(sequence, "data/test.json")
+	testSequence := ReadJSON("data/test.json")
+
+	os.Remove("data/test.json")
+
+	fmt.Println(testSequence.Meta.Source)
+	//output: Saccharomyces cerevisiae (baker's yeast)
+}
 
 func TestJSONIO(t *testing.T) {
 	testSequence := ReadGbk("data/bsub.gbk")

--- a/io_test.go
+++ b/io_test.go
@@ -1,6 +1,7 @@
 package poly
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -26,6 +27,25 @@ FASTA - fasta tests.
 Gff related tests and benchmarks begin here.
 
 ******************************************************************************/
+
+func ExampleReadGff() {
+
+	sequence := ReadGff("data/ecoli-mg1655.gff")
+	fmt.Println(sequence.Meta.Name)
+	// Output: U00096.3
+}
+
+func ExampleParseGff() {
+
+}
+
+func ExampleBuildGff() {
+
+}
+
+func ExampleWriteGff() {
+
+}
 
 // TODO should delete output files.
 func TestGffIO(t *testing.T) {

--- a/io_test.go
+++ b/io_test.go
@@ -1,10 +1,7 @@
 package poly
 
 import (
-<<<<<<< HEAD
-=======
 	"bytes"
->>>>>>> 67bc453e3db06ce93201176b5145c491633d0a18
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -40,15 +37,31 @@ func ExampleReadGff() {
 }
 
 func ExampleParseGff() {
+	file, _ := ioutil.ReadFile("data/ecoli-mg1655.gff")
+	sequence := ParseGff(string(file))
 
+	fmt.Println(sequence.Meta.Name)
+	// Output: U00096.3
 }
 
 func ExampleBuildGff() {
 
+	sequence := ReadGff("data/ecoli-mg1655.gff")
+	gffString := BuildGff(sequence)
+	reparsedSequence := ParseGff(string(gffString))
+
+	fmt.Println(reparsedSequence.Meta.Name)
+	// Output: U00096.3
+
 }
 
 func ExampleWriteGff() {
+	sequence := ReadGff("data/ecoli-mg1655.gff")
+	WriteGff(sequence, "data/test.gff")
+	testSequence := ReadGff("data/test.gff")
 
+	fmt.Println(testSequence.Meta.Name)
+	// Output: U00096.3
 }
 
 // TODO should delete output files.

--- a/io_test.go
+++ b/io_test.go
@@ -124,6 +124,38 @@ Gbk/gb/genbank related benchmarks begin here.
 
 ******************************************************************************/
 
+func ExampleReadGbk() {
+	sequence := ReadGbk("data/puc19.gbk")
+	fmt.Println(sequence.Meta.Locus.ModificationDate)
+	// Output: 22-OCT-2019
+}
+
+func ExampleParseGbk() {
+	file, _ := ioutil.ReadFile("data/puc19.gbk")
+	sequence := ParseGbk(string(file))
+
+	fmt.Println(sequence.Meta.Locus.ModificationDate)
+	// Output: 22-OCT-2019
+}
+
+func ExampleBuildGbk() {
+	sequence := ReadGbk("data/puc19.gbk")
+	gbkBytes := BuildGbk(sequence)
+	testSequence := ParseGbk(string(gbkBytes))
+
+	fmt.Println(testSequence.Meta.Locus.ModificationDate)
+	// Output: 22-OCT-2019
+}
+
+func ExampleWriteGbk() {
+	sequence := ReadGbk("data/puc19.gbk")
+	WriteGbk(sequence, "data/test.gbk")
+	testSequence := ReadGbk("data/test.gbk")
+
+	fmt.Println(testSequence.Meta.Locus.ModificationDate)
+	// Output: 22-OCT-2019
+}
+
 func TestGbkIO(t *testing.T) {
 	gbk := ReadGbk("data/puc19.gbk")
 	WriteGbk(gbk, "data/puc19gbktest.gbk")

--- a/io_test.go
+++ b/io_test.go
@@ -38,7 +38,7 @@ func ExampleReadGff() {
 
 func ExampleParseGff() {
 	file, _ := ioutil.ReadFile("data/ecoli-mg1655.gff")
-	sequence := ParseGff(string(file))
+	sequence := ParseGff(file)
 
 	fmt.Println(sequence.Meta.Name)
 	// Output: U00096.3
@@ -47,8 +47,8 @@ func ExampleParseGff() {
 func ExampleBuildGff() {
 
 	sequence := ReadGff("data/ecoli-mg1655.gff")
-	gffString := BuildGff(sequence)
-	reparsedSequence := ParseGff(string(gffString))
+	gffBytes := BuildGff(sequence)
+	reparsedSequence := ParseGff(gffBytes)
 
 	fmt.Println(reparsedSequence.Meta.Name)
 	// Output: U00096.3
@@ -104,7 +104,7 @@ func TestGffIO(t *testing.T) {
 
 func BenchmarkReadGff(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		ParseGff("data/ecoli-mg1655.gff")
+		ReadGff("data/ecoli-mg1655.gff")
 	}
 }
 
@@ -134,7 +134,7 @@ func ExampleReadGbk() {
 
 func ExampleParseGbk() {
 	file, _ := ioutil.ReadFile("data/puc19.gbk")
-	sequence := ParseGbk(string(file))
+	sequence := ParseGbk(file)
 
 	fmt.Println(sequence.Meta.Locus.ModificationDate)
 	// Output: 22-OCT-2019
@@ -143,7 +143,7 @@ func ExampleParseGbk() {
 func ExampleBuildGbk() {
 	sequence := ReadGbk("data/puc19.gbk")
 	gbkBytes := BuildGbk(sequence)
-	testSequence := ParseGbk(string(gbkBytes))
+	testSequence := ParseGbk(gbkBytes)
 
 	fmt.Println(testSequence.Meta.Locus.ModificationDate)
 	// Output: 22-OCT-2019
@@ -347,7 +347,7 @@ func ExampleReadFASTA() {
 
 func ExampleParseFASTA() {
 	file, _ := ioutil.ReadFile("data/base.fasta")
-	sequence := ParseFASTA(string(file))
+	sequence := ParseFASTA(file)
 
 	fmt.Println(sequence.Features[0].Description)
 	// Output: gi|5524211|gb|AAD44166.1| cytochrome b [Elephas maximus maximus]

--- a/poly/commands.go
+++ b/poly/commands.go
@@ -364,7 +364,7 @@ func translateCommand(c *cli.Context) error {
 }
 
 // a simple helper function to convert an *os.File type into a string.
-func stdinToString(file io.Reader) string {
+func stdinToBytes(file io.Reader) []byte {
 	var stringBuffer bytes.Buffer
 	reader := bufio.NewReader(file)
 	for {
@@ -374,7 +374,7 @@ func stdinToString(file io.Reader) string {
 		}
 		stringBuffer.WriteRune(input)
 	}
-	return stringBuffer.String()
+	return stringBuffer.Bytes()
 }
 
 // a simple helper function to remove duplicates from a list of strings.
@@ -420,13 +420,13 @@ func parseStdin(c *cli.Context) poly.Sequence {
 	var sequence poly.Sequence
 	// logic for determining input format, then parses accordingly.
 	if c.String("i") == "json" {
-		json.Unmarshal([]byte(stdinToString(c.App.Reader)), &sequence)
+		json.Unmarshal([]byte(stdinToBytes(c.App.Reader)), &sequence)
 	} else if c.String("i") == "gbk" || c.String("i") == "gb" {
-		sequence = poly.ParseGbk(stdinToString(c.App.Reader))
+		sequence = poly.ParseGbk(stdinToBytes(c.App.Reader))
 	} else if c.String("i") == "gff" {
-		sequence = poly.ParseGff(stdinToString(c.App.Reader))
+		sequence = poly.ParseGff(stdinToBytes(c.App.Reader))
 	} else if c.String("i") == "string" {
-		sequence.Sequence = stdinToString(c.App.Reader)
+		sequence.Sequence = string(stdinToBytes(c.App.Reader))
 	}
 	return sequence
 }


### PR DESCRIPTION
I've refactored parsing functions to accept bytes instead of strings. Most use cases ended up converting bytes to string before input.