### PR TITLE
Seqhash v1

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -116,7 +116,7 @@ func Seqhash(sequence string, sequenceType string, circular bool, doubleStranded
 
 	// Run checks on the input
 	if sequenceType != "DNA" && sequenceType != "RNA" && sequenceType != "PROTEIN" {
-		return "", errors.New("Only sequenceTypes of DNA, RNA, or PROTEIN allowed")
+		return "", errors.New("Only sequenceTypes of DNA, RNA, or PROTEIN allowed. Got sequenceType: " + sequenceType)
 	}
 	if sequenceType == "DNA" || sequenceType == "RNA" {
 		for _, char := range sequence {
@@ -129,7 +129,7 @@ func Seqhash(sequence string, sequenceType string, circular bool, doubleStranded
 		for _, char := range sequence {
 			// Selenocysteine (Sec; U) and pyrrolysine (Pyl; O) are added
 			// in accordance with https://www.uniprot.org/help/sequences
-			if !strings.Contains("ACDEFGHIKLMNPQRSTVWYUO", string(char)) {
+			if !strings.Contains("ACDEFGHIKLMNPQRSTVWYUO*", string(char)) {
 				return "", errors.New("Only letters ACDEFGHIKLMNPQRSTVWYUO are allowed for Proteins. Got letter: " + string(char))
 			}
 		}

--- a/hash.go
+++ b/hash.go
@@ -143,7 +143,7 @@ store that relate to storing and searching large quantities of sequences - dedup
 be used on those Seqhashes to save a lot of space.
 
 For DNA or RNA sequences, only ATUGCYRSWKMBDHVNZ characters are allowed. For Proteins,
-only ACDEFGHIKLMNPQRSTVWYUO* characters are allowed in sequences. Selenocysteine (Sec; U) and pyrrolysine
+only ACDEFGHIKLMNPQRSTVWYUO*BXZ characters are allowed in sequences. Selenocysteine (Sec; U) and pyrrolysine
 (Pyl; O) are included in the protein character set - usually U and O don't occur within protein sequences,
 but for certain organisms they do, and it is certainly a relevant amino acid for those particular proteins.
 

--- a/hash.go
+++ b/hash.go
@@ -166,7 +166,7 @@ Keoni
 
 ******************************************************************************/
 
-// Seqhash is a function to create Seqhashes, a specific kind of identifier
+// Seqhash is a function to create Seqhashes, a specific kind of identifier.
 func Seqhash(sequence string, sequenceType string, circular bool, doubleStranded bool) (string, error) {
 	// By definition, Seqhashes are of uppercase sequences
 	sequence = strings.ToUpper(sequence)

--- a/hash.go
+++ b/hash.go
@@ -106,29 +106,13 @@ func RotateSequence(sequence string) string {
 	return sequence
 }
 
-var sequenceCharMap = map[rune]rune{'A': 'T', 'T': 'A', 'U': 'A', 'G': 'C', 'C': 'G', 'Y': 'R', 'R': 'Y', 'S': 'S', 'W': 'W', 'K': 'M', 'M': 'K', 'B': 'V', 'D': 'H', 'H': 'D', 'V': 'B', 'N': 'N', 'Z': 'Z'}
-
-func ReverseComplement(sequence string) string {
-	n := len(sequence)
-	complement := make([]rune, n)
-	reverseComplement := make([]rune, n)
-	for _, char := range strings.ToUpper(sequence) {
-		complement = append(complement, sequenceCharMap[char])
-	}
-	for _, char := range complement {
-		n--
-		reverseComplement[n] = char
-	}
-	return string(reverseComplement[n:])
-}
-
 // SeqHash is a function to create SeqHashes, a specific kind of identifier
 func SeqHash(sequence string, sequenceType string, circular bool, doubleStranded bool) (string, error) {
 	// By definition, SeqHashes are of uppercase sequences
 	sequence = strings.ToUpper(sequence)
 
 	// Run checks on the input
-	if sequenceType != "DNA" || sequenceType != "RNA" || sequenceType != "PROTEIN" {
+	if sequenceType != "DNA" && sequenceType != "RNA" && sequenceType != "PROTEIN" {
 		return "", errors.New("Only sequenceTypes of DNA, RNA, or PROTEIN allowed")
 	}
 	if sequenceType == "DNA" || sequenceType == "RNA" {

--- a/hash.go
+++ b/hash.go
@@ -106,13 +106,75 @@ func RotateSequence(sequence string) string {
 	return sequence
 }
 
+/******************************************************************************
+Dec, 2, 2020
+
+Seqhash stuff starts here.
+
+There is a big problem with current sequence databases - they all use different
+identifiers and accession numbers. This means cross-referencing databases is
+a complicated exercise, especially as the quantity of databases increases, or if
+you need to compare "wild" DNA sequences.
+
+Seqhash is a simple algorithm to produce consistent identifiers for any genetic sequence. The
+basic premise of the Seqhash algorithm is to hash sequences with the hash being a robust
+cross-database identifier. Sequences themselves shouldn't be used as a database index
+(often, they're too big), so a hash based off of a sequence is the next best thing.
+
+Usability wise, you should be able to Seqhash any rotation of a sequence in any direction and
+get a consistent hash.
+
+The Seqhash algorithm makes several opinionated design choices, primarily to make working
+with Seqhashes more consistent and nice. The Seqhash algorithm only uses a single hash function,
+Blake3, and only operates on DNA, RNA, and Protein sequences. These identifiers will be seen
+by human beings, so versioning and metadata is attached to the front of the hashes so that
+a human operator can quickly identify problems with hashing.
+
+If the sequence is DNA or RNA, the Seqhash algorithm needs to know whether or not the nucleic
+acid is circular and/or double stranded. If circular, the sequence is rotated to a deterministic
+point. If double stranded, the sequence is compared to its reverse complement, and the lexiographically
+minimal sequence is taken (whether or not the min or max is used doesn't matter, just needs to
+be consistent).
+
+If the sequence is RNA, the sequence will be converted to DNA before hashing. While the full Seqhash
+will still be different between RNA and DNA (due to the metadata string), the hash afterwards will be the same.
+This makes it easy to cross reference DNA and RNA sequences. This fact is important for parts of Poly
+store that relate to storing and searching large quantities of sequences - deduplication can easily
+be used on those Seqhashes to save a lot of space.
+
+For DNA or RNA sequences, only ATUGCYRSWKMBDHVNZ characters are allowed. For Proteins,
+only ACDEFGHIKLMNPQRSTVWYUO* characters are allowed in sequences. Selenocysteine (Sec; U) and pyrrolysine
+(Pyl; O) are included in the protein character set - usually U and O don't occur within protein sequences,
+but for certain organisms they do, and it is certainly a relevant amino acid for those particular proteins.
+
+A Seqhash is separated into 3 different elements divided by underscores. It looks like the following:
+
+v1_DCD_4b0616d1b3fc632e42d78521deb38b44fba95cca9fde159e01cd567fa996ceb9
+
+The first element is the version tag (v1 for version 1). If there is ever a Seqhash version 2, this tag
+will differentiate seqhashes. The second element is the metadata tag, which has 3 letters. The first letter
+codes for the sequenceType (D for DNA, R for RNA, and P for Protein). The second letter codes for whether or
+not the sequence is circular (C for Circular, L for Linear). The final letter codes for whether or not the
+sequence is double stranded (D for Double stranded, S for Single stranded). The final element is the blake3
+hash of the sequence (once rotated and complemented, as stated above).
+
+Seqhash is a simple algorithm that allows for much better indexing of genetic sequences than what is
+currently available. I hope it will be widely adopted someday.
+
+En Taro Adun,
+Keoni
+
+******************************************************************************/
+
 // Seqhash is a function to create Seqhashes, a specific kind of identifier
 func Seqhash(sequence string, sequenceType string, circular bool, doubleStranded bool) (string, error) {
 	// By definition, Seqhashes are of uppercase sequences
 	sequence = strings.ToUpper(sequence)
 	// If RNA, convert to a DNA sequence. The hash itself between a DNA and RNA sequence will not
 	// be different, but their Seqhash will have a different metadata string (R vs D)
-	sequence = strings.ReplaceAll(sequence, "U", "T")
+	if sequenceType == "RNA" {
+		sequence = strings.ReplaceAll(sequence, "U", "T")
+	}
 
 	// Run checks on the input
 	if sequenceType != "DNA" && sequenceType != "RNA" && sequenceType != "PROTEIN" {

--- a/hash.go
+++ b/hash.go
@@ -191,10 +191,11 @@ func Seqhash(sequence string, sequenceType string, circular bool, doubleStranded
 		for _, char := range sequence {
 			// Selenocysteine (Sec; U) and pyrrolysine (Pyl; O) are added
 			// in accordance with https://www.uniprot.org/help/sequences
-			// X and Z are added since Uniprot files do have these in sequences
-			// scattered about
-			if !strings.Contains("ACDEFGHIKLMNPQRSTVWYUO*XZ", string(char)) {
-				return "", errors.New("Only letters ACDEFGHIKLMNPQRSTVWYUO*XZ are allowed for Proteins. Got letter: " + string(char))
+			// The release notes https://web.expasy.org/docs/relnotes/relstat.html
+			// also state there are Asx (B), Glx (Z), and Xaa (X) amino acids, so
+			// these are added in as well.
+			if !strings.Contains("ACDEFGHIKLMNPQRSTVWYUO*BXZ", string(char)) {
+				return "", errors.New("Only letters ACDEFGHIKLMNPQRSTVWYUO*BXZ are allowed for Proteins. Got letter: " + string(char))
 			}
 		}
 	}

--- a/hash.go
+++ b/hash.go
@@ -234,7 +234,7 @@ func Seqhash(sequence string, sequenceType string, circular bool, doubleStranded
 	case "PROTEIN":
 		sequenceTypeLetter = "P"
 	}
-	// Get 2nd letter. C for circular, L for Liner
+	// Get 2nd letter. C for circular, L for Linear
 	if circular == true {
 		circularLetter = "C"
 	} else {

--- a/hash.go
+++ b/hash.go
@@ -253,7 +253,7 @@ func Seqhash(sequence string, sequenceType string, circular bool, doubleStranded
 
 }
 
-// Seqhash is a method wrapper for hashing Sequence structs. Note that
+// SequenceSeqhash is a method wrapper for hashing Sequence structs. Note that
 // all sequence structs are, by default, double-stranded sequences,
 // since Genbank does not track whether or not a given sequence in their
 // database is single stranded or double stranded.

--- a/hash.go
+++ b/hash.go
@@ -253,11 +253,11 @@ func Seqhash(sequence string, sequenceType string, circular bool, doubleStranded
 
 }
 
-// SequenceSeqhash is a method wrapper for hashing Sequence structs. Note that
+// Seqhash is a method wrapper for hashing Sequence structs. Note that
 // all sequence structs are, by default, double-stranded sequences,
 // since Genbank does not track whether or not a given sequence in their
 // database is single stranded or double stranded.
-func (sequence Sequence) SequenceSeqhash() (string, error) {
+func (sequence Sequence) Seqhash() (string, error) {
 	if sequence.Meta.Locus.MoleculeType == "" {
 		return "", errors.New("No MoleculeType found for sequence")
 	}

--- a/hash.go
+++ b/hash.go
@@ -191,8 +191,10 @@ func Seqhash(sequence string, sequenceType string, circular bool, doubleStranded
 		for _, char := range sequence {
 			// Selenocysteine (Sec; U) and pyrrolysine (Pyl; O) are added
 			// in accordance with https://www.uniprot.org/help/sequences
-			if !strings.Contains("ACDEFGHIKLMNPQRSTVWYUO*", string(char)) {
-				return "", errors.New("Only letters ACDEFGHIKLMNPQRSTVWYUO are allowed for Proteins. Got letter: " + string(char))
+			// X and Z are added since Uniprot files do have these in sequences
+			// scattered about
+			if !strings.Contains("ACDEFGHIKLMNPQRSTVWYUO*XZ", string(char)) {
+				return "", errors.New("Only letters ACDEFGHIKLMNPQRSTVWYUO*XZ are allowed for Proteins. Got letter: " + string(char))
 			}
 		}
 	}

--- a/hash.go
+++ b/hash.go
@@ -106,7 +106,7 @@ func RotateSequence(sequence string) string {
 	return sequence
 }
 
-// Seqhash is a function to create SeqHashes, a specific kind of identifier
+// Seqhash is a function to create Seqhashes, a specific kind of identifier
 func Seqhash(sequence string, sequenceType string, circular bool, doubleStranded bool) (string, error) {
 	// By definition, Seqhashes are of uppercase sequences
 	sequence = strings.ToUpper(sequence)
@@ -134,6 +134,7 @@ func Seqhash(sequence string, sequenceType string, circular bool, doubleStranded
 			}
 		}
 	}
+	// There is no check for circular proteins since proteins can be circular
 	if sequenceType == "PROTEIN" && doubleStranded == true {
 		return "", errors.New("Proteins cannot be double stranded")
 	}

--- a/hash_test.go
+++ b/hash_test.go
@@ -84,12 +84,12 @@ func ExampleSeqhash() {
 	// output: v1_DCD_4b0616d1b3fc632e42d78521deb38b44fba95cca9fde159e01cd567fa996ceb9
 }
 
-func ExampleSequenceSeqhash() {
+func ExampleSeqhashMethod() {
 	sequence := ReadGbk("data/puc19.gbk")
 
-	// SequenceSeqhash assumes doubleStranded sequence and defaults to linear
+	// Seqhash assumes doubleStranded sequence and defaults to linear
 	// if sequence.Meta.Locus.Circular is not set
-	seqhash, _ := sequence.SequenceSeqhash()
+	seqhash, _ := sequence.Seqhash()
 	fmt.Println(seqhash)
 	// output: v1_DCD_4b0616d1b3fc632e42d78521deb38b44fba95cca9fde159e01cd567fa996ceb9
 }
@@ -155,26 +155,26 @@ func TestSeqhashMethod(t *testing.T) {
 	// Test no MoleculeType
 	sequence := ReadGbk("data/puc19.gbk")
 	sequence.Meta.Locus.MoleculeType = ""
-	_, err := sequence.SequenceSeqhash()
+	_, err := sequence.Seqhash()
 	if err == nil {
 		t.Errorf("Seqhash method should fail with no MoleculeType")
 	}
 	// Test RNA sequence feature
 	sequence.Meta.Locus.MoleculeType = "RNA"
-	seqhash, _ := sequence.SequenceSeqhash()
+	seqhash, _ := sequence.Seqhash()
 	if seqhash != "v1_RCD_4b0616d1b3fc632e42d78521deb38b44fba95cca9fde159e01cd567fa996ceb9" {
 		t.Errorf("RNA hashing failed. Expected v1_RCD_4b0616d1b3fc632e42d78521deb38b44fba95cca9fde159e01cd567fa996ceb9, got: " + seqhash)
 	}
 	// Test bad MoleculeType
 	sequence.Meta.Locus.MoleculeType = "TNA"
-	_, err = sequence.SequenceSeqhash()
+	_, err = sequence.Seqhash()
 	if err == nil {
 		t.Errorf("Seqhash method should fail with TNA (or other) MoleculeType")
 	}
 	// Test bad sequence
 	sequence.Meta.Locus.MoleculeType = "DNA"
 	sequence.Sequence = "gagatacctacagcgtgagctatgagaaagcgccacgcttcccgaagggagaaaggcggacaggtatccggtaagcggcagggtcggaacaggagagcgcacgagggagcttccagggggaaacgcctggtatctttatagtcctgtcgggtttcgccacctctgacttgagcgtcgatttttgtgatgctcgtcaggggggcggagcctatggaaaaacgccagcaacgcggcctttttacggttcctggccttttgctggccttttgctcacatgttctttcctgcgttatcccctgattctgtggataaccgtattaccgcctttgagtgagctgataccgctcgccgcagccgaacgaccgagcgcagcgagtcagtgagcgaggaagcggaagagcgcccaatacgcaaaccgcctctccccgcgcgttggccgattcattaatgcagctggcacgacaggtttcccgactggaaagcgggcagtgagcgcaacgcaattaatgtgagttagctcactcattaggcaccccaggctttacactttatgcttccggctcgtatgttgtgtggaattgtgagcggataacaatttcacacaggaaacagctatgaccatgattacgccaagcttgcatgcctgcaggtcgactctagaggatccccgggtaccgagctcgaattcactggccgtcgttttacaacgtcgtgactgggaaaaccctggcgttacccaacttaatcgccttgcagcacatccccctttcgccagctggcgtaatagcgaagaggcccgcaccgatcgcccttcccaacagttgcgcagcctgaatggcgaatggcgcctgatgcggtattttctccttacgcatctgtgcggtatttcacaccgcatatggtgcactctcagtacaatctgctctgatgccgcatagttaagccagccccgacacccgccaacacccgctgacgcgccctgacgggcttgtctgctcccggcatccgcttacagacaagctgtgaccgtctccgggagctgcatgtgtcagaggttttcaccgtcatcaccgaaacgcgcgagacgaaagggcctcgtgatacgcctatttttataggttaatgtcatgataataatggtttcttagacgtcaggtggcacttttcggggaaatgtgcgcggaacccctatttgtttatttttctaaatacattcaaatatgtatccgctcatgagacaataaccctgataaatgcttcaataatattgaaaaaggaagagtatgagtattcaacatttccgtgtcgcccttattcccttttttgcggcattttgccttcctgtttttgctcacccagaaacgctggtgaaagtaaaagatgctgaagatcagttgggtgcacgagtgggttacatcgaactggatctcaacagcggtaagatccttgagagttttcgccccgaagaacgttttccaatgatgagcacttttaaagttctgctatgtggcgcggtattatcccgtattgacgccgggcaagagcaactcggtcgccgcatacactattctcagaatgacttggttgagtactcaccagtcacagaaaagcatcttacggatggcatgacagtaagagaattatgcagtgctgccataaccatgagtgataacactgcggccaacttacttctgacaacgatcggaggaccgaaggagctaaccgcttttttgcacaacatgggggatcatgtaactcgccttgatcgttgggaaccggagctgaatgaagccataccaaacgacgagcgtgacaccacgatgcctgtagcaatggcaacaacgttgcgcaaactattaactggcgaactacttactctagcttcccggcaacaattaatagactggatggaggcggataaagttgcaggaccacttctgcgctcggcccttccggctggctggtttattgctgataaatctggagccggtgagcgtgggtctcgcggtatcattgcagcactggggccagatggtaagccctcccgtatcgtagttatctacacgacggggagtcaggcaactatggatgaacgaaatagacagatcgctgagataggtgcctcactgattaagcattggtaactgtcagaccaagtttactcatatatactttagattgatttaaaacttcatttttaatttaaaaggatctaggtgaagatcctttttgataatctcatgaccaaaatcccttaacgtgagttttcgttccactgagcgtcagaccccgtagaaaagatcaaaggatcttcttgagatcctttttttctgcgcgtaatctgctgcttgcaaacaaaaaaaccaccgctaccagcggtggtttgtttgccggatcaagagctaccaactctttttccgaaggtaactggcttcagcagagcgcagataccaaatactgttcttctagtgtagccgtagttaggccaccacttcaagaactctgtagcaccgcctacatacctcgctctgctaatcctgttaccagtggctgctgccagtggcgataagtcgtgtcttaccgggttggactcaagacgatagttaccggataaggcgcagcggtcgggctgaacggggggttcgtgcacacagcccagcttggagcgaacgacctacaccgaactx"
-	_, err = sequence.SequenceSeqhash()
+	_, err = sequence.Seqhash()
 	if err == nil {
 		t.Errorf("Seqhash method should fail with X nucleotide")
 	}

--- a/hash_test.go
+++ b/hash_test.go
@@ -106,9 +106,9 @@ func TestSeqhash(t *testing.T) {
 		t.Errorf("TestSeqhashSequenceString() has failed. X is not a valid DNA or RNA sequence character.")
 	}
 	// Test X in PROTEIN
-	_, err = Seqhash("MGCX*", "PROTEIN", false, false)
+	_, err = Seqhash("MGCB*", "PROTEIN", false, false)
 	if err == nil {
-		t.Errorf("TestSeqhashSequenceProteinString() has failed. X is not a valid PROTEIN sequence character.")
+		t.Errorf("TestSeqhashSequenceProteinString() has failed. B is not a valid PROTEIN sequence character.")
 		fmt.Println(err)
 	}
 	// Test double stranded Protein

--- a/hash_test.go
+++ b/hash_test.go
@@ -106,9 +106,9 @@ func TestSeqhash(t *testing.T) {
 		t.Errorf("TestSeqhashSequenceString() has failed. X is not a valid DNA or RNA sequence character.")
 	}
 	// Test X in PROTEIN
-	_, err = Seqhash("MGCB*", "PROTEIN", false, false)
+	_, err = Seqhash("MGCJ*", "PROTEIN", false, false)
 	if err == nil {
-		t.Errorf("TestSeqhashSequenceProteinString() has failed. B is not a valid PROTEIN sequence character.")
+		t.Errorf("TestSeqhashSequenceProteinString() has failed. J is not a valid PROTEIN sequence character.")
 		fmt.Println(err)
 	}
 	// Test double stranded Protein

--- a/hash_test.go
+++ b/hash_test.go
@@ -93,3 +93,89 @@ func ExampleSequenceSeqhash() {
 	fmt.Println(seqhash)
 	// output: v1_DCD_4b0616d1b3fc632e42d78521deb38b44fba95cca9fde159e01cd567fa996ceb9
 }
+
+func TestSeqhash(t *testing.T) {
+	// Test TNA as sequenceType
+	_, err := Seqhash("ATGGGCTAA", "TNA", true, true)
+	if err == nil {
+		t.Errorf("TestSeqhash() has failed. TNA is not a valid sequenceType.")
+	}
+	// Test X in DNA or RNA
+	_, err = Seqhash("XTGGCCTAA", "DNA", true, true)
+	if err == nil {
+		t.Errorf("TestSeqhashSequenceString() has failed. X is not a valid DNA or RNA sequence character.")
+	}
+	// Test X in PROTEIN
+	_, err = Seqhash("MGCX*", "PROTEIN", false, false)
+	if err == nil {
+		t.Errorf("TestSeqhashSequenceProteinString() has failed. X is not a valid PROTEIN sequence character.")
+		fmt.Println(err)
+	}
+	// Test double stranded Protein
+	_, err = Seqhash("MGCS*", "PROTEIN", false, true)
+	if err == nil {
+		t.Errorf("TestSeqhashProteinDoubleStranded() has failed. Proteins cannot be double stranded.")
+	}
+
+	// Test circular double stranded hashing
+	seqhash, _ := Seqhash("TTAGCCCAT", "DNA", true, true)
+	if seqhash != "v1_DCD_a376845b679740014f3eb501429b45e592ecc32a6ba8ba922cbe99217f6e9287" {
+		t.Errorf("Circular double stranded hashing failed. Expected v1_DCD_a376845b679740014f3eb501429b45e592ecc32a6ba8ba922cbe99217f6e9287, got: " + seqhash)
+	}
+	// Test circular single stranded hashing
+	seqhash, _ = Seqhash("TTAGCCCAT", "DNA", true, false)
+	if seqhash != "v1_DCS_ef79b6e62394e22a176942dfc6a5e62eeef7b5281ffcb2686ecde208ec836ba4" {
+		t.Errorf("Circular single stranded hashing failed. Expected v1_DCS_ef79b6e62394e22a176942dfc6a5e62eeef7b5281ffcb2686ecde208ec836ba4, got: " + seqhash)
+	}
+	// Test linear double stranded hashing
+	seqhash, _ = Seqhash("TTAGCCCAT", "DNA", false, true)
+	if seqhash != "v1_DLD_c2c9fc44df72035082a152e94b04492182331bc3be2f62729d203e072211bdbf" {
+		t.Errorf("Linear double stranded hashing failed. Expected v1_DLD_c2c9fc44df72035082a152e94b04492182331bc3be2f62729d203e072211bdbf, got: " + seqhash)
+	}
+	// Test linear single stranded hashing
+	seqhash, _ = Seqhash("TTAGCCCAT", "DNA", false, false)
+	if seqhash != "v1_DLS_063ea37d1154351639f9a48546bdae62fd8a3c18f3d3d3061060c9a55352d967" {
+		t.Errorf("Linear single stranded hashing failed. Expected v1_DLS_063ea37d1154351639f9a48546bdae62fd8a3c18f3d3d3061060c9a55352d967, got: " + seqhash)
+	}
+
+	// Test RNA Seqhash
+	seqhash, _ = Seqhash("TTAGCCCAT", "RNA", false, false)
+	if seqhash != "v1_RLS_063ea37d1154351639f9a48546bdae62fd8a3c18f3d3d3061060c9a55352d967" {
+		t.Errorf("Linear single stranded hashing failed. Expected v1_RLS_063ea37d1154351639f9a48546bdae62fd8a3c18f3d3d3061060c9a55352d967, got: " + seqhash)
+	}
+	// Test Protein Seqhash
+	seqhash, _ = Seqhash("MGC*", "PROTEIN", false, false)
+	if seqhash != "v1_PLS_922ec11f5227ce77a42f07f565a7a1a479772b5cf3f1f6e93afc5ecbc0fd5955" {
+		t.Errorf("Linear single stranded hashing failed. Expected v1_PLS_922ec11f5227ce77a42f07f565a7a1a479772b5cf3f1f6e93afc5ecbc0fd5955, got: " + seqhash)
+	}
+
+}
+
+func TestSeqhashMethod(t *testing.T) {
+	// Test no MoleculeType
+	sequence := ReadGbk("data/puc19.gbk")
+	sequence.Meta.Locus.MoleculeType = ""
+	_, err := sequence.SequenceSeqhash()
+	if err == nil {
+		t.Errorf("Seqhash method should fail with no MoleculeType")
+	}
+	// Test RNA sequence feature
+	sequence.Meta.Locus.MoleculeType = "RNA"
+	seqhash, _ := sequence.SequenceSeqhash()
+	if seqhash != "v1_RCD_4b0616d1b3fc632e42d78521deb38b44fba95cca9fde159e01cd567fa996ceb9" {
+		t.Errorf("RNA hashing failed. Expected v1_RCD_4b0616d1b3fc632e42d78521deb38b44fba95cca9fde159e01cd567fa996ceb9, got: " + seqhash)
+	}
+	// Test bad MoleculeType
+	sequence.Meta.Locus.MoleculeType = "TNA"
+	_, err = sequence.SequenceSeqhash()
+	if err == nil {
+		t.Errorf("Seqhash method should fail with TNA (or other) MoleculeType")
+	}
+	// Test bad sequence
+	sequence.Meta.Locus.MoleculeType = "DNA"
+	sequence.Sequence = "gagatacctacagcgtgagctatgagaaagcgccacgcttcccgaagggagaaaggcggacaggtatccggtaagcggcagggtcggaacaggagagcgcacgagggagcttccagggggaaacgcctggtatctttatagtcctgtcgggtttcgccacctctgacttgagcgtcgatttttgtgatgctcgtcaggggggcggagcctatggaaaaacgccagcaacgcggcctttttacggttcctggccttttgctggccttttgctcacatgttctttcctgcgttatcccctgattctgtggataaccgtattaccgcctttgagtgagctgataccgctcgccgcagccgaacgaccgagcgcagcgagtcagtgagcgaggaagcggaagagcgcccaatacgcaaaccgcctctccccgcgcgttggccgattcattaatgcagctggcacgacaggtttcccgactggaaagcgggcagtgagcgcaacgcaattaatgtgagttagctcactcattaggcaccccaggctttacactttatgcttccggctcgtatgttgtgtggaattgtgagcggataacaatttcacacaggaaacagctatgaccatgattacgccaagcttgcatgcctgcaggtcgactctagaggatccccgggtaccgagctcgaattcactggccgtcgttttacaacgtcgtgactgggaaaaccctggcgttacccaacttaatcgccttgcagcacatccccctttcgccagctggcgtaatagcgaagaggcccgcaccgatcgcccttcccaacagttgcgcagcctgaatggcgaatggcgcctgatgcggtattttctccttacgcatctgtgcggtatttcacaccgcatatggtgcactctcagtacaatctgctctgatgccgcatagttaagccagccccgacacccgccaacacccgctgacgcgccctgacgggcttgtctgctcccggcatccgcttacagacaagctgtgaccgtctccgggagctgcatgtgtcagaggttttcaccgtcatcaccgaaacgcgcgagacgaaagggcctcgtgatacgcctatttttataggttaatgtcatgataataatggtttcttagacgtcaggtggcacttttcggggaaatgtgcgcggaacccctatttgtttatttttctaaatacattcaaatatgtatccgctcatgagacaataaccctgataaatgcttcaataatattgaaaaaggaagagtatgagtattcaacatttccgtgtcgcccttattcccttttttgcggcattttgccttcctgtttttgctcacccagaaacgctggtgaaagtaaaagatgctgaagatcagttgggtgcacgagtgggttacatcgaactggatctcaacagcggtaagatccttgagagttttcgccccgaagaacgttttccaatgatgagcacttttaaagttctgctatgtggcgcggtattatcccgtattgacgccgggcaagagcaactcggtcgccgcatacactattctcagaatgacttggttgagtactcaccagtcacagaaaagcatcttacggatggcatgacagtaagagaattatgcagtgctgccataaccatgagtgataacactgcggccaacttacttctgacaacgatcggaggaccgaaggagctaaccgcttttttgcacaacatgggggatcatgtaactcgccttgatcgttgggaaccggagctgaatgaagccataccaaacgacgagcgtgacaccacgatgcctgtagcaatggcaacaacgttgcgcaaactattaactggcgaactacttactctagcttcccggcaacaattaatagactggatggaggcggataaagttgcaggaccacttctgcgctcggcccttccggctggctggtttattgctgataaatctggagccggtgagcgtgggtctcgcggtatcattgcagcactggggccagatggtaagccctcccgtatcgtagttatctacacgacggggagtcaggcaactatggatgaacgaaatagacagatcgctgagataggtgcctcactgattaagcattggtaactgtcagaccaagtttactcatatatactttagattgatttaaaacttcatttttaatttaaaaggatctaggtgaagatcctttttgataatctcatgaccaaaatcccttaacgtgagttttcgttccactgagcgtcagaccccgtagaaaagatcaaaggatcttcttgagatcctttttttctgcgcgtaatctgctgcttgcaaacaaaaaaaccaccgctaccagcggtggtttgtttgccggatcaagagctaccaactctttttccgaaggtaactggcttcagcagagcgcagataccaaatactgttcttctagtgtagccgtagttaggccaccacttcaagaactctgtagcaccgcctacatacctcgctctgctaatcctgttaccagtggctgctgccagtggcgataagtcgtgtcttaccgggttggactcaagacgatagttaccggataaggcgcagcggtcgggctgaacggggggttcgtgcacacagcccagcttggagcgaacgacctacaccgaactx"
+	_, err = sequence.SequenceSeqhash()
+	if err == nil {
+		t.Errorf("Seqhash method should fail with X nucleotide")
+	}
+}

--- a/hash_test.go
+++ b/hash_test.go
@@ -69,3 +69,27 @@ func TestLeastRotation(t *testing.T) {
 	}
 
 }
+
+/******************************************************************************
+
+Seqhash related tests begin here.
+
+******************************************************************************/
+
+func ExampleSeqhash() {
+	sequence := ReadGbk("data/puc19.gbk")
+
+	seqhash, _ := Seqhash(sequence.Sequence, "DNA", true, true)
+	fmt.Println(seqhash)
+	// output: v1_DCD_4b0616d1b3fc632e42d78521deb38b44fba95cca9fde159e01cd567fa996ceb9
+}
+
+func ExampleSequenceSeqhash() {
+	sequence := ReadGbk("data/puc19.gbk")
+
+	// SequenceSeqhash assumes doubleStranded sequence and defaults to linear
+	// if sequence.Meta.Locus.Circular is not set
+	seqhash, _ := sequence.SequenceSeqhash()
+	fmt.Println(seqhash)
+	// output: v1_DCD_4b0616d1b3fc632e42d78521deb38b44fba95cca9fde159e01cd567fa996ceb9
+}

--- a/io.go
+++ b/io.go
@@ -325,13 +325,9 @@ func BuildGff(sequence Sequence) []byte {
 
 // ReadGff takes in a filepath for a .gffv3 file and parses it into an Annotated Sequence struct.
 func ReadGff(path string) Sequence {
-	file, err := ioutil.ReadFile(path)
+	file, _ := ioutil.ReadFile(path)
 	var sequence Sequence
-	if err != nil {
-		// return 0, fmt.Errorf("Failed to open file %s for unpack: %s", gzFilePath, err)
-	} else {
-		sequence = ParseGff(file)
-	}
+	sequence = ParseGff(file)
 	return sequence
 }
 
@@ -368,10 +364,7 @@ func ParseJSON(file []byte) Sequence {
 
 // ReadJSON reads an Sequence JSON file.
 func ReadJSON(path string) Sequence {
-	file, err := ioutil.ReadFile(path)
-	if err != nil {
-		// return 0, fmt.Errorf("Failed to open file %s for unpack: %s", gzFilePath, err)
-	}
+	file, _ := ioutil.ReadFile(path)
 	sequence := ParseJSON(file)
 	return sequence
 }
@@ -499,10 +492,7 @@ func BuildFASTA(sequence Sequence) []byte {
 
 // ReadFASTA reads a Sequence struct from a FASTA file.
 func ReadFASTA(path string) Sequence {
-	file, err := ioutil.ReadFile(path)
-	if err != nil {
-		// return 0, fmt.Errorf("Failed to open file %s for unpack: %s", gzFilePath, err)
-	}
+	file, _ := ioutil.ReadFile(path)
 	sequence := ParseFASTA(file)
 	return sequence
 }
@@ -715,14 +705,9 @@ func BuildGbk(sequence Sequence) []byte {
 
 // ReadGbk reads a Gbk from path and parses into an Annotated sequence struct.
 func ReadGbk(path string) Sequence {
-	file, err := ioutil.ReadFile(path)
+	file, _ := ioutil.ReadFile(path)
 	var sequence Sequence
-	if err != nil {
-		// return 0, fmt.Errorf("Failed to open file %s for unpack: %s", gzFilePath, err)
-	} else {
-		sequence = ParseGbk(file)
-
-	}
+	sequence = ParseGbk(file)
 	return sequence
 }
 
@@ -1451,20 +1436,14 @@ func ParseGbkFlat(file []byte) []Sequence {
 
 // ReadGbkMulti reads multiple genbank files from a single file
 func ReadGbkMulti(path string) []Sequence {
-	file, err := ioutil.ReadFile(path)
-	if err != nil {
-		// return 0, fmt.Errorf("Failed to open file %s for unpack: %s", gzFilePath, err)
-	}
+	file, _ := ioutil.ReadFile(path)
 	sequences := ParseGbkMulti(file)
 	return sequences
 }
 
 // ReadGbkFlat reads flat genbank files, like the ones provided by the NCBI FTP server
 func ReadGbkFlat(path string) []Sequence {
-	file, err := ioutil.ReadFile(path)
-	if err != nil {
-		// return 0, fmt.Errorf("Failed to open file %s for unpack: %s", gzFilePath, err)
-	}
+	file, _ := ioutil.ReadFile(path)
 	sequences := ParseGbkFlat(file)
 	return sequences
 }


### PR DESCRIPTION
This PR adds the Seqhash function and SequenceSeqhash method to Sequence structs. 

Briefly, the algorithm uniquely hashes DNA, RNA, and Protein sequences. It checks for properly formed sequences (no X nucleotide or amino acids) and has full test coverage with written examples.

Seqhash's primary use case is navigation between different databases. In particular, they can be used to do a full comparison of Genbank <-> Uniprot to get EC numbers for any protein. 