### PR TITLE
Added CompromiseCodonTable to Poly

### DIFF
--- a/data/phix174.gb
+++ b/data/phix174.gb
@@ -1,0 +1,268 @@
+LOCUS       CP004084                5386 bp    DNA     circular PHG 04-MAR-2015
+DEFINITION  Enterobacteria phage phiX174, complete genome.
+ACCESSION   CP004084
+VERSION     CP004084.1
+DBLINK      BioProject: PRJNA182589
+            BioSample: SAMN03379850
+KEYWORDS    .
+SOURCE      Escherichia virus phiX174
+  ORGANISM  Escherichia virus phiX174
+            Viruses; Monodnaviria; Sangervirae; Phixviricota;
+            Malgrandaviricetes; Petitvirales; Microviridae; Bullavirinae;
+            Sinsheimervirus.
+REFERENCE   1  (bases 1 to 5386)
+  AUTHORS   Tian,B. and Moran,N.A.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (21-JAN-2013) Department of Integrative Biology,
+            University of Texas, 2506 Speedway A5000, Austin, TX 78712, USA
+COMMENT     Source DNA/bacteria from Nancy Moran, University of Texas at
+            Austin.
+FEATURES             Location/Qualifiers
+     source          1..5386
+                     /organism="Escherichia virus phiX174"
+                     /mol_type="genomic DNA"
+                     /strain="bta3-1"
+                     /isolation_source="honeybee gut"
+                     /host="Enterobacteriaceae bacterium bta3-1"
+                     /db_xref="taxon:10847"
+                     /country="USA"
+     gene            join(3981..5386,1..136)
+                     /locus_tag="F652_4273"
+     CDS             join(3981..5386,1..136)
+                     /locus_tag="F652_4273"
+                     /note="DNA replication initiation protein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="protein A"
+                     /protein_id="AJR02264.1"
+                     /translation="MVRSYYPSECHADYFDFERIEALKPAIEACGISTLSQSPMLGFH
+                     KQMDNRIKLLEEILSFRMQGVEFDNGDMYVDGHKAASDVRDEFVSVTEKLMDELAQCY
+                     NVLPQLDINNTIDHRPEGDEKWFLENEKTVTQFCRKLAAERPLKDIRDEYNYPKKKGI
+                     KDECSRLLEASTMKSRRGFAIQRLMNAMRQAHADGWFIVFDTLTLADDRLEAFYDNPN
+                     ALRDYFRDIGRMVLAAEGRKANDSHADCYQYFCVPEYGTANGRLHFHAVHFMRTLPTG
+                     SVDPNFGRRVRNRRQLNSLQNTWPYGYSMPIAVRYTQDAFSRSGWLWPVDAKGEPLKA
+                     TSYMAVGFYVAKYVNKKSDMDLAAKGLGAKEWNNSLKTKLSLLPKKLFRIRMSRNFGM
+                     KMLTMTNLSTECLIQLTKLGYDATPFNQILKQNAKREMRLRLGKVTVADVLAAQPVTT
+                     NLLKFMRASIKMIGVSNLQSFIASMTQKLTLSDISDESKNYLDKAGITTACLRIKSKW
+                     TAGGK"
+     gene            join(4497..5386,1..136)
+                     /locus_tag="F652_4274"
+     CDS             join(4497..5386,1..136)
+                     /locus_tag="F652_4274"
+                     /note="replication initiation protein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="protein A*"
+                     /protein_id="AJR02262.1"
+                     /translation="MKSRRGFAIQRLMNAMRQAHADGWFIVFDTLTLADDRLEAFYDN
+                     PNALRDYFRDIGRMVLAAEGRKANDSHADCYQYFCVPEYGTANGRLHFHAVHFMRTLP
+                     TGSVDPNFGRRVRNRRQLNSLQNTWPYGYSMPIAVRYTQDAFSRSGWLWPVDAKGEPL
+                     KATSYMAVGFYVAKYVNKKSDMDLAAKGLGAKEWNNSLKTKLSLLPKKLFRIRMSRNF
+                     GMKMLTMTNLSTECLIQLTKLGYDATPFNQILKQNAKREMRLRLGKVTVADVLAAQPV
+                     TTNLLKFMRASIKMIGVSNLQSFIASMTQKLTLSDISDESKNYLDKAGITTACLRIKS
+                     KWTAGGK"
+     gene            join(5075..5386,1..51)
+                     /locus_tag="F652_4275"
+     CDS             join(5075..5386,1..51)
+                     /locus_tag="F652_4275"
+                     /note="internal scaffolding protein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="protein B"
+                     /protein_id="AJR02263.1"
+                     /translation="MEQLTKNQAVATSQEAVQNQNEPQLRDENAHNDKSVHGVLNPTY
+                     QAGLRRDAVQPDIEAERKKRDEIEAGKSYCSRRFGGATCDDKSAQIYARFDKNDWRIQ
+                     PAEFYRFHDAEVNTFGYF"
+     gene            51..221
+                     /locus_tag="F652_4278"
+     CDS             51..221
+                     /locus_tag="F652_4278"
+                     /note="unknown protein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="protein K"
+                     /protein_id="AJR02265.1"
+                     /translation="MSRKIILIKQELLLLVYELNRSGLLAENEKIRPILAQLEKLLLC
+                     DLSPSTNDSVKN"
+     gene            133..393
+                     /locus_tag="F652_4283"
+     CDS             133..393
+                     /locus_tag="F652_4283"
+                     /note="DNA maturation"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="protein C"
+                     /protein_id="AJR02266.1"
+                     /translation="MRKFDLSLRSSRSSYFATFRHQLTILSKTDALDEEKWLNMLGTF
+                     VKDWFRYESHFVHGRDSLVDILKERGLLSESDAVQPLIGKKS"
+     gene            390..848
+                     /locus_tag="F652_4288"
+     CDS             390..848
+                     /locus_tag="F652_4288"
+                     /note="external scaffolding protein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="protein D"
+                     /protein_id="AJR02267.1"
+                     /translation="MSQVTEQSVRFQTALASIKLIQASAVLDLTEDDFDFLTSNKVWI
+                     ATDRSRARRCVEACVYGTLDFVGYPRFPAPVEFIAAVIAYYVHPVNIQTACLIMEGAE
+                     FTENIINGVERPVKAAELFAFTLRVRAGNTDVLTDAEENVRQKLRAEGVM"
+     gene            643..843
+                     /locus_tag="F652_4293"
+     CDS             643..843
+                     /locus_tag="F652_4293"
+                     /note="cell lysis protein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="protein E"
+                     /protein_id="AJR02268.1"
+                     /translation="MFIPSTFKRPVSSWKALNLRKTLLMASSVRLKPLNCSRLPCVYA
+                     QETLTFLLTQKKTCVKNYVQKE"
+     gene            848..964
+                     /locus_tag="F652_4298"
+     CDS             848..964
+                     /locus_tag="F652_4298"
+                     /note="core protein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="protein J"
+                     /protein_id="AJR02269.1"
+                     /translation="MSKGKKRSGARPGRPQPLRGTKGKRKGARLWYVGGQQF"
+     gene            1001..2284
+                     /locus_tag="F652_4303"
+     CDS             1001..2284
+                     /locus_tag="F652_4303"
+                     /note="capsid protein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="protein F"
+                     /protein_id="AJR02270.1"
+                     /translation="MSNIQTGAERMPHDLSHLGFLAGQIGRLITISTTPVIAGDSFEM
+                     DAVGALRLSPLRRGLAIDSTVDIFTFYVPHRHVYGEQWIKFMKDGVNATPLPTVNTTG
+                     YIDHAAFLGTINPDTNKIPKHLFQGYLNIYNNYFKAPWMPDRTEANPNELNQDDARYG
+                     FRCCHLKNIWTAPLPPETELSRQMTTSTTSIDIMGLQAAYANLHTDQERDYFMQRYHD
+                     VISSFGGKTSYDADNRPLLVMRSNLWASGYDVDGTDQTSLGQFSGRVQQTYKHSVPRF
+                     FVPEHGTMFTLALVRFPPTATKEIQYLNAKGALTYTDIAGDPVLYGNLPPREISMKDV
+                     FRSGDSSKKFKIAEGQWYRYAPSYVSPAYHLLEGFPFIQEPPSGDLQERVLIRHHDYD
+                     QCFQSVQLLQWNSQVKFNVTVYRNLPTTRDSIMTS"
+     gene            2395..2922
+                     /locus_tag="F652_4308"
+     CDS             2395..2922
+                     /locus_tag="F652_4308"
+                     /note="major spike protein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="protein G"
+                     /protein_id="AJR02271.1"
+                     /translation="MFQTFISRHNSNFFSDKLVLTSVTPASSAPVLQTPKATSSTLYF
+                     DSLTVNAGNGGFLHCIQMDTSVNAANQVVSVGADIAFDADPKFFACLVRFESSSVPTT
+                     LPTAYDVYPLDGRHDGGYYTVKDCVTIDVLPRTPGNNVYVGFMVWSNFTATKCRGLVS
+                     LNQVIKEIICLQPLK"
+     gene            2931..3917
+                     /locus_tag="F652_4313"
+     CDS             2931..3917
+                     /locus_tag="F652_4313"
+                     /note="minor spike protein"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="protein H"
+                     /protein_id="AJR02272.1"
+                     /translation="MFGAIAGGIASALAGGAMSKLFGGGQKAASGGIQGDVLATDNNT
+                     VGMGDAGIKSAIQGSNVPNPDEAVPSFVSGAMAKAGKGLLEGTLQAGTSAVSDKLLDL
+                     VGLGGKSAADKGKDTRDYLAAAFPELNAWERAGADASSAGMVDAGFENQKELTKMQLD
+                     NQKEIAEMQNETQKEIAGIQSATSRQNTKDQVYAQNEMLAYQQKESTARVASIMENTN
+                     LSKQQQVSEIMRQMLTQAQTAGQYFTNDQIKEMTRKVSAEVDLVHQQTQNQRYGSSHI
+                     GATAKDISNVVTDAASGVVDIFHGIDKAVADTWNNFWKDGKADGIGSNLSRK"
+ORIGIN      
+        1 gagttttatc gcttccatga cgcagaagtt aacactttcg gatatttctg atgagtcgaa
+       61 aaattatctt gataaagcag gaattactac tgcttgttta cgaattaaat cgaagtggac
+      121 tgctggcgga aaatgagaaa attcgaccta tccttgcgca gctcgagaag ctcttacttt
+      181 gcgacctttc gccatcaact aacgattctg tcaaaaactg acgcgttgga tgaggagaag
+      241 tggcttaata tgcttggcac gttcgtcaag gactggttta gatatgagtc acattttgtt
+      301 catggtagag attctcttgt tgacatttta aaagagcgtg gattactatc tgagtccgat
+      361 gctgttcaac cactaatagg taagaaatca tgagtcaagt tactgaacaa tccgtacgtt
+      421 tccagaccgc tttggcctct attaagctca ttcaggcttc tgccgttttg gatttaaccg
+      481 aagatgattt cgattttctg acgagtaaca aagtttggat tgctactgac cgctctcgtg
+      541 ctcgtcgctg cgttgaggct tgcgtttatg gtacgctgga ctttgtagga taccctcgct
+      601 ttcctgctcc tgttgagttt attgctgccg tcattgctta ttatgttcat cccgtcaaca
+      661 ttcaaacggc ctgtctcatc atggaaggcg ctgaatttac ggaaaacatt attaatggcg
+      721 tcgagcgtcc ggttaaagcc gctgaattgt tcgcgtttac cttgcgtgta cgcgcaggaa
+      781 acactgacgt tcttactgac gcagaagaaa acgtgcgtca aaaattacgt gcagaaggag
+      841 tgatgtaatg tctaaaggta aaaaacgttc tggcgctcgc cctggtcgtc cgcagccgtt
+      901 gcgaggtact aaaggcaagc gtaaaggcgc tcgtctttgg tatgtaggtg gtcaacaatt
+      961 ttaattgcag gggcttcggc cccttacttg aggataaatt atgtctaata ttcaaactgg
+     1021 cgccgagcgt atgccgcatg acctttccca tcttggcttc cttgctggtc agattggtcg
+     1081 tcttattacc atttcaacta ctccggttat cgctggcgac tccttcgaga tggacgccgt
+     1141 tggcgctctc cgtctttctc cattgcgtcg tggccttgct attgactcta ctgtagacat
+     1201 ttttactttt tatgtccctc atcgtcacgt ttatggtgaa cagtggatta agttcatgaa
+     1261 ggatggtgtt aatgccactc ctctcccgac tgttaacact actggttata ttgaccatgc
+     1321 cgcttttctt ggcacgatta accctgatac caataaaatc cctaagcatt tgtttcaggg
+     1381 ttatttgaat atctataaca actattttaa agcgccgtgg atgcctgacc gtaccgaggc
+     1441 taaccctaat gagcttaatc aagatgatgc tcgttatggt ttccgttgct gccatctcaa
+     1501 aaacatttgg actgctccgc ttcctcctga gactgagctt tctcgccaaa tgacgacttc
+     1561 taccacatct attgacatta tgggtctgca agctgcttat gctaatttgc atactgacca
+     1621 agaacgtgat tacttcatgc agcgttacca tgatgttatt tcttcatttg gaggtaaaac
+     1681 ctcttatgac gctgacaacc gtcctttact tgtcatgcgc tctaatctct gggcatctgg
+     1741 ctatgatgtt gatggaactg accaaacgtc gttaggccag ttttctggtc gtgttcaaca
+     1801 gacctataaa cattctgtgc cgcgtttctt tgttcctgag catggcacta tgtttactct
+     1861 tgcgcttgtt cgttttccgc ctactgcgac taaagagatt cagtacctta acgctaaagg
+     1921 tgctttgact tataccgata ttgctggcga ccctgttttg tatggcaact tgccgccgcg
+     1981 tgaaatttct atgaaggatg ttttccgttc tggtgattcg tctaagaagt ttaagattgc
+     2041 tgagggtcag tggtatcgtt atgcgccttc gtatgtttct cctgcttatc accttcttga
+     2101 aggcttccca ttcattcagg aaccgccttc tggtgatttg caagaacgcg tacttattcg
+     2161 ccaccatgat tatgaccagt gtttccagtc cgttcagttg ttgcagtgga atagtcaggt
+     2221 taaatttaat gtgaccgttt atcgcaatct gccgaccact cgcgattcaa tcatgacttc
+     2281 gtgataaaag attgagtgtg aggttataac gccgaagcgg taaaaatttt aatttttgcc
+     2341 gctgaggggt tgaccaagcg aagcgcggta ggttttctgc ttaggagttt aatcatgttt
+     2401 cagactttta tttctcgcca taattcaaac tttttttctg ataagctggt tctcacttct
+     2461 gttactccag cttcttcggc acctgtttta cagacaccta aagctacatc gtcaacgtta
+     2521 tattttgata gtttgacggt taatgctggt aatggtggtt ttcttcattg cattcagatg
+     2581 gatacatctg tcaacgccgc taatcaggtt gtttctgttg gtgctgatat tgcttttgat
+     2641 gccgacccta aattttttgc ctgtttggtt cgctttgagt cttcttcggt tccgactacc
+     2701 ctcccgactg cctatgatgt ttatcctttg gatggtcgcc atgatggtgg ttattatacc
+     2761 gtcaaggact gtgtgactat tgacgtcctt ccccgtacgc cgggcaataa tgtttatgtt
+     2821 ggtttcatgg tttggtctaa ctttaccgct actaaatgcc gcggattggt ttcgctgaat
+     2881 caggttatta aagagattat ttgtctccag ccacttaagt gaggtgattt atgtttggtg
+     2941 ctattgctgg cggtattgct tctgctcttg ctggtggcgc catgtctaaa ttgtttggag
+     3001 gcggtcaaaa agccgcctcc ggtggcattc aaggtgatgt gcttgctacc gataacaata
+     3061 ctgtaggcat gggtgatgct ggtattaaat ctgccattca aggctctaat gttcctaacc
+     3121 ctgatgaggc cgtccctagt tttgtttctg gtgctatggc taaagctggt aaaggacttc
+     3181 ttgaaggtac gttgcaggct ggcacttctg ccgtttctga taagttgctt gatttggttg
+     3241 gacttggtgg caagtctgcc gctgataaag gaaaggatac tcgtgattat cttgctgctg
+     3301 catttcctga gcttaatgct tgggagcgtg ctggtgctga tgcttcctct gctggtatgg
+     3361 ttgacgccgg atttgagaat caaaaagagc ttactaaaat gcaactggac aatcagaaag
+     3421 agattgccga gatgcaaaat gagactcaaa aagagattgc tggcattcag tcggcgactt
+     3481 cacgccagaa tacgaaagac caggtatatg cacaaaatga gatgcttgct tatcaacaga
+     3541 aggagtctac tgctcgcgtt gcgtctatta tggaaaacac caatctttcc aagcaacagc
+     3601 aggtttccga gattatgcgc caaatgctta ctcaagctca aacggctggt cagtatttta
+     3661 ccaatgacca aatcaaagaa atgactcgca aggttagtgc tgaggttgac ttagttcatc
+     3721 agcaaacgca gaatcagcgg tatggctctt ctcatattgg cgctactgca aaggatattt
+     3781 ctaatgtcgt cactgatgct gcttctggtg tggttgatat ttttcatggt attgataaag
+     3841 ctgttgccga tacttggaac aatttctgga aagacggtaa agctgatggt attggctcta
+     3901 atttgtctag gaaataaccg tcaggattga caccctccca attgtatgtt ttcatgcctc
+     3961 caaatcttgg aggctttttt atggttcgtt cttattaccc ttctgaatgt cacgctgatt
+     4021 attttgactt tgagcgtatc gaggctctta aacctgctat tgaggcttgt ggcatttcta
+     4081 ctctttctca atccccaatg cttggcttcc ataagcagat ggataaccgc atcaagctct
+     4141 tggaagagat tctgtctttt cgtatgcagg gcgttgagtt cgataatggt gatatgtatg
+     4201 ttgacggcca taaggctgct tctgacgttc gtgatgagtt tgtatctgtt actgagaagt
+     4261 taatggatga attggcacaa tgctacaatg tgctccccca acttgatatt aataacacta
+     4321 tagaccaccg ccccgaaggg gacgaaaaat ggtttttaga gaacgagaag acggttacgc
+     4381 agttttgccg caagctggct gctgaacgcc ctcttaagga tattcgcgat gagtataatt
+     4441 accccaaaaa gaaaggtatt aaggatgagt gttcaagatt gctggaggcc tccactatga
+     4501 aatcgcgtag aggctttgct attcagcgtt tgatgaatgc aatgcgacag gctcatgctg
+     4561 atggttggtt tatcgttttt gacactctca cgttggctga cgaccgatta gaggcgtttt
+     4621 atgataatcc caatgctttg cgtgactatt ttcgtgatat tggtcgtatg gttcttgctg
+     4681 ccgagggtcg caaggctaat gattcacacg ccgactgcta tcagtatttt tgtgtgcctg
+     4741 agtatggtac agctaatggc cgtcttcatt tccatgcggt gcactttatg cggacacttc
+     4801 ctacaggtag cgttgaccct aattttggtc gtcgggtacg caatcgccgc cagttaaata
+     4861 gcttgcaaaa tacgtggcct tatggttaca gtatgcccat cgcagttcgc tacacgcagg
+     4921 acgctttttc acgttctggt tggttgtggc ctgttgatgc taaaggtgag ccgcttaaag
+     4981 ctaccagtta tatggctgtt ggtttctatg tggctaaata cgttaacaaa aagtcagata
+     5041 tggaccttgc tgctaaaggt ctaggagcta aagaatggaa caactcacta aaaaccaagc
+     5101 tgtcgctact tcccaagaag ctgttcagaa tcagaatgag ccgcaacttc gggatgaaaa
+     5161 tgctcacaat gacaaatctg tccacggagt gcttaatcca acttaccaag ctgggttacg
+     5221 acgcgacgcc gttcaaccag atattgaagc agaacgcaaa aagagagatg agattgaggc
+     5281 tgggaaaagt tactgtagcc gacgttttgg cggcgcaacc tgtgacgaca aatctgctca
+     5341 aatttatgcg cgcttcgata aaaatgattg gcgtatccaa cctgca
+//
+

--- a/transformations.go
+++ b/transformations.go
@@ -469,6 +469,7 @@ Keoni
 // CompromiseCodonTable takes 2 CodonTables and makes a new CodonTable
 // that is an equal compromise between the two tables.
 func CompromiseCodonTable(firstCodonTable CodonTable, secondCodonTable CodonTable, cutOff float64) (CodonTable, error) {
+	// Initialize output CodonTable, c
 	var c CodonTable
 	// Check if cutOff is too high or low (this is converted to a percent)
 	if cutOff < 0 {
@@ -479,13 +480,14 @@ func CompromiseCodonTable(firstCodonTable CodonTable, secondCodonTable CodonTabl
 	}
 
 	// Take start and stop strings from first table
+	// and use them as start + stops in final CodonTable
 	c.StartCodons = firstCodonTable.StartCodons
 	c.StopCodons = firstCodonTable.StopCodons
 
 	// Initialize the finalAminoAcid list for the output CodonTable
 	var finalAminoAcids []AminoAcid
 
-	// Loop over all Aa in first CodonTable, and add the
+	// Loop over all AminoAcids represented in the first CodonTable
 	for _, firstAa := range firstCodonTable.AminoAcids {
 		var firstTriplets []string
 		var firstWeights []int

--- a/transformations.go
+++ b/transformations.go
@@ -440,8 +440,10 @@ func WriteCodonJSON(codontable CodonTable, path string) {
 /******************************************************************************
 Dec, 17, 2020
 
-Compromise codon table stuff begins here
+Compromise + Add codon table stuff begins here
 
+
+== Compromise tables ==
 Basically, I want to codon optimize a protein for two or more organisms.
 In order to do that, I need to be able to generate a codon table that
 is a compromise between the codon tables between two different organisms.
@@ -453,6 +455,11 @@ tables lossy).
 
 Simple code, but very powerful if it can be used to encode genes for
 multiple organisms.
+
+== Add tables ==
+Some organisms have multiple chromosomes. We need to add em all up
+to get an accurate codon table (different than compromise tables,
+since these are all already balanced).
 
 Godspeed,
 
@@ -525,4 +532,30 @@ func CompromiseCodonTable(firstCodonTable CodonTable, secondCodonTable CodonTabl
 	}
 	c.AminoAcids = finalAminoAcids
 	return c, nil
+}
+
+func AddCodonTable(firstCodonTable CodonTable, secondCodonTable CodonTable) CodonTable {
+	var c CodonTable
+
+	// Take start and stop strings from first table
+	c.StartCodons = firstCodonTable.StartCodons
+	c.StopCodons = firstCodonTable.StopCodons
+
+	// Add up codons
+	var finalAminoAcids []AminoAcid
+	for _, firstAa := range firstCodonTable.AminoAcids {
+		var finalCodons []Codon
+		for _, firstCodon := range firstAa.Codons {
+			for _, secondAa := range secondCodonTable.AminoAcids {
+				for _, secondCodon := range secondAa.Codons {
+					if firstCodon.Triplet == secondCodon.Triplet {
+						finalCodons = append(finalCodons, Codon{firstCodon.Triplet, firstCodon.Weight + secondCodon.Weight})
+					}
+				}
+			}
+		}
+		finalAminoAcids = append(finalAminoAcids, AminoAcid{firstAa.Letter, finalCodons})
+	}
+	c.AminoAcids = finalAminoAcids
+	return c
 }

--- a/transformations.go
+++ b/transformations.go
@@ -466,6 +466,8 @@ Godspeed,
 Keoni
 ******************************************************************************/
 
+// CompromiseCodonTable takes 2 CodonTables and makes a new CodonTable
+// that is an equal compromise between the two tables.
 func CompromiseCodonTable(firstCodonTable CodonTable, secondCodonTable CodonTable, cutOff float64) (CodonTable, error) {
 	var c CodonTable
 	if cutOff < 0 {
@@ -534,6 +536,8 @@ func CompromiseCodonTable(firstCodonTable CodonTable, secondCodonTable CodonTabl
 	return c, nil
 }
 
+// AddCodonTable takes 2 CodonTables and adds them together to create
+// a new CodonTable.
 func AddCodonTable(firstCodonTable CodonTable, secondCodonTable CodonTable) CodonTable {
 	var c CodonTable
 

--- a/transformations_test.go
+++ b/transformations_test.go
@@ -154,3 +154,48 @@ func TestWriteCodonJSON(t *testing.T) {
 	}
 
 }
+
+/******************************************************************************
+
+Codon Compromise related tests begin here.
+
+******************************************************************************/
+
+func ExampleCompromiseCodonTable() {
+	sequence := ReadGbk("data/puc19.gbk")
+	codonTable := GetCodonTable(11)
+	optimizationTable := sequence.GetOptimizationTable(codonTable)
+
+	sequence2 := ReadGbk("data/phix174.gb")
+	codonTable2 := GetCodonTable(11)
+	optimizationTable2 := sequence2.GetOptimizationTable(codonTable2)
+
+	finalTable, _ := CompromiseCodonTable(optimizationTable, optimizationTable2, 0.1)
+	for _, aa := range finalTable.AminoAcids {
+		for _, codon := range aa.Codons {
+			if codon.Triplet == "TAA" {
+				fmt.Println(codon.Weight)
+			}
+		}
+	}
+	//output: 2727
+}
+
+func TestCompromiseCodonTable(t *testing.T) {
+	sequence := ReadGbk("data/puc19.gbk")
+	codonTable := GetCodonTable(11)
+	optimizationTable := sequence.GetOptimizationTable(codonTable)
+
+	sequence2 := ReadGbk("data/phix174.gb")
+	codonTable2 := GetCodonTable(11)
+	optimizationTable2 := sequence2.GetOptimizationTable(codonTable2)
+
+	_, err := CompromiseCodonTable(optimizationTable, optimizationTable2, -1.0) // Fails too low
+	if err == nil {
+		t.Errorf("Compromise table should fail on -1.0")
+	}
+	_, err = CompromiseCodonTable(optimizationTable, optimizationTable2, 10.0) // Fails too high
+	if err == nil {
+		t.Errorf("Compromise table should fail on 10.0")
+	}
+}

--- a/transformations_test.go
+++ b/transformations_test.go
@@ -157,7 +157,7 @@ func TestWriteCodonJSON(t *testing.T) {
 
 /******************************************************************************
 
-Codon Compromise related tests begin here.
+Codon Compromise + Add related tests begin here.
 
 ******************************************************************************/
 
@@ -198,4 +198,24 @@ func TestCompromiseCodonTable(t *testing.T) {
 	if err == nil {
 		t.Errorf("Compromise table should fail on 10.0")
 	}
+}
+
+func ExampleAddCodonTable() {
+	sequence := ReadGbk("data/puc19.gbk")
+	codonTable := GetCodonTable(11)
+	optimizationTable := sequence.GetOptimizationTable(codonTable)
+
+	sequence2 := ReadGbk("data/phix174.gb")
+	codonTable2 := GetCodonTable(11)
+	optimizationTable2 := sequence2.GetOptimizationTable(codonTable2)
+
+	finalTable := AddCodonTable(optimizationTable, optimizationTable2)
+	for _, aa := range finalTable.AminoAcids {
+		for _, codon := range aa.Codons {
+			if codon.Triplet == "GGC" {
+				fmt.Println(codon.Weight)
+			}
+		}
+	}
+	//output: 90
 }


### PR DESCRIPTION
Adds a single function called `CompromiseCodonTable` to transformations.go

This function takes 2 codon tables and compromises them together. Very useful for creating compromise tables between E.coli and B.subtilis for example (I would like to use this for some genes I am optimizing for formate bioutilization).

