### PR TITLE
fixed generic import paths for hash functions.

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -1,21 +1,12 @@
 package poly
 
 import (
-	_ "crypto/md5"
-	_ "crypto/sha1"
-	_ "crypto/sha256"
-	_ "crypto/sha512"
 	"encoding/hex"
 	"errors"
 	"hash"
 	"io"
 	"sort"
 	"strings"
-
-	_ "golang.org/x/crypto/blake2b"
-	_ "golang.org/x/crypto/blake2s"
-	_ "golang.org/x/crypto/ripemd160"
-	_ "golang.org/x/crypto/sha3"
 
 	"lukechampine.com/blake3"
 )

--- a/poly/main.go
+++ b/poly/main.go
@@ -1,10 +1,19 @@
 package main
 
 import (
+	_ "crypto/md5"
+	_ "crypto/sha1"
+	_ "crypto/sha256"
+	_ "crypto/sha512"
 	"log"
 	"os"
 
 	"github.com/urfave/cli/v2"
+
+	_ "golang.org/x/crypto/blake2b"
+	_ "golang.org/x/crypto/blake2s"
+	_ "golang.org/x/crypto/ripemd160"
+	_ "golang.org/x/crypto/sha3"
 )
 
 /******************************************************************************


### PR DESCRIPTION
Code climate was complaining about generic exports outside of main.go for the command line tool. So I moved them.