### PR TITLE
Add random protein sequence function

### DIFF
--- a/sequence.go
+++ b/sequence.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"strings"
         "math/rand"
-        "fmt"
         "errors"
 )
 
@@ -98,12 +97,11 @@ func getFeatureSequence(feature Feature, location Location) string {
 
 
 //RandomProteinSequence returns a random protein sequence as a string that have size n, starts with aminoacid M and finishes with aminoacid *. The random generator uses the seed provided as parameter.
-func RandomProteinSequence(n int, seed int64) string {
+func RandomProteinSequence(n int, seed int64) (string, error) {
 
         if n <= 2 {
-            err := errors.New("The parameter n should be higher than 2, please select another n in RandomProteinSequence") 
-            fmt.Print(err)
-            return ""
+            err := errors.New("The parameter n should be higher than 2, please select another n in RandomProteinSequence")
+            return "", err
         }
 
         var aminoAcidsAlphabet = []rune("ACEDGFIHKLNQPSRTWVY")
@@ -122,5 +120,5 @@ func RandomProteinSequence(n int, seed int64) string {
             }
         }
 
-        return string(randomSequence)
+        return string(randomSequence), nil
 }

--- a/sequence.go
+++ b/sequence.go
@@ -3,6 +3,9 @@ package poly
 import (
 	"bytes"
 	"strings"
+        "math/rand"
+        "fmt"
+        "errors"
 )
 
 // complementBaseRuneMap provides 1:1 mapping between bases and their complements
@@ -91,4 +94,33 @@ func getFeatureSequence(feature Feature, location Location) string {
 	}
 
 	return sequenceString
+}
+
+
+//RandomProteinSequence returns a random protein sequence as a string that have size n, starts with aminoacid M and finishes with aminoacid *. The random generator uses the seed provided as parameter.
+func RandomProteinSequence(n int, seed int64) string {
+
+        if n <= 2 {
+            err := errors.New("The parameter n should be higher than 2, please select another n in RandomProteinSequence") 
+            fmt.Print(err)
+            return ""
+        }
+
+        var aminoAcidsAlphabet = []rune("ACEDGFIHKLNQPSRTWVY")
+        rand.Seed(seed)
+
+        randomSequence := make([]rune, n)
+
+        for i := range randomSequence {
+            if (i == 0) {
+                randomSequence[i] = 'M'
+            } else if (i == n-1) {
+                randomSequence[i] = '*'
+            } else {
+                randomIndex := rand.Intn(len(aminoAcidsAlphabet))
+                randomSequence[i] = aminoAcidsAlphabet[randomIndex]
+            }
+        }
+
+        return string(randomSequence)
 }

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -74,7 +74,7 @@ func TestLocationParser(t *testing.T) {
 
 func ExampleRandomProteinSequence() {
 
-	randomProtein := RandomProteinSequence(15, 2)
+	randomProtein, _ := RandomProteinSequence(15, 2)
 	fmt.Println(randomProtein)
 	// Output: MGLLTAVNIFGNNP*
 }
@@ -82,7 +82,7 @@ func ExampleRandomProteinSequence() {
 func TestRandomProteinSequence(t *testing.T) {
         const n = 10
         const seed = 2
-        sequence := RandomProteinSequence(n, seed)
+        sequence, _ := RandomProteinSequence(n, seed)
         
         if sequence[0] != 'M' {
             t.Errorf("Random sequence doesn't have the correct initial aminoacid in sequence 'RandomSequence(10, 2)'. Got this: \n%s instead of \n%s", string(sequence[0]), "M")
@@ -102,7 +102,7 @@ func TestRandomProteinSequence(t *testing.T) {
 func TestRandomProteinSequenceError (t *testing.T) {
         const n = 2
         const seed = 4
-        sequence := RandomProteinSequence(n, seed)
+        sequence, _ := RandomProteinSequence(n, seed)
         
 
          if len(sequence) != 0 {

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -2,6 +2,8 @@ package poly
 
 import (
 	"testing"
+        "strconv"
+        "fmt"
 )
 
 func TestGetSequenceMethods(t *testing.T) {
@@ -69,3 +71,42 @@ func TestLocationParser(t *testing.T) {
 		t.Errorf("Feature sequence parser has changed on test 'complement(join(893..1098,1101..2770))'. Got this:\n%s instead of \n%s", featureComplementJoin, seqComplementJoin)
 	}
 }
+
+func ExampleRandomProteinSequence() {
+
+	randomProtein := RandomProteinSequence(15, 2)
+	fmt.Println(randomProtein)
+	// Output: MGLLTAVNIFGNNP*
+}
+
+func TestRandomProteinSequence(t *testing.T) {
+        const n = 10
+        const seed = 2
+        sequence := RandomProteinSequence(n, seed)
+        
+        if sequence[0] != 'M' {
+            t.Errorf("Random sequence doesn't have the correct initial aminoacid in sequence 'RandomSequence(10, 2)'. Got this: \n%s instead of \n%s", string(sequence[0]), "M")
+        }
+
+        if sequence[len(sequence)-1] != '*' {
+            t.Errorf("Random sequence doesn't have correct last aminoacid in sequence 'RandomSequence(10, 2)'. Got this: \n%s instead of \n%s", string(sequence[len(sequence)-1]), "*")
+        }
+
+        if len(sequence) != n {
+            t.Errorf("Random sequence doesn't have the sequence size equal parameter passed through n 'RandomSequence(10, 2)'. Got this: \n%s instead of \n%s", strconv.Itoa(len(sequence)), strconv.Itoa(n))
+        }
+}
+
+
+// Write a new case of test when you have a n inferior than 3
+func TestRandomProteinSequenceError (t *testing.T) {
+        const n = 2
+        const seed = 4
+        sequence := RandomProteinSequence(n, seed)
+        
+
+         if len(sequence) != 0 {
+            t.Errorf("Random sequence must have sequence size equals 0 'RandomSequence(2, 4)'. Got this: \n%s instead of \n%s", strconv.Itoa(len(sequence)), strconv.Itoa(n))
+        }
+}
+ 


### PR DESCRIPTION
The following feature/random-protein-sequence has the feature random_protein_sequence requested in the #91 easy_dna port. I will show here how this function is [tested](https://github.com/Edinburgh-Genome-Foundry/easy_dna/blob/14f694d549682bd0e2aeaa136cc82c0f20015c11/tests/test_random_sequences.py#L13) and [implemented](https://github.com/Edinburgh-Genome-Foundry/easy_dna/blob/14f694d549682bd0e2aeaa136cc82c0f20015c11/easy_dna/random_sequences.py#L47) in easy_dna for reference, if needed.