### PR TITLE
Delete file parser

### DIFF
--- a/poly/commands.go
+++ b/poly/commands.go
@@ -75,8 +75,6 @@ func convertCommand(c *cli.Context) error {
 		// gets glob pattern matches to determine which files to use.
 		matches := getMatches(c)
 
-		// TODO write basic check to see if input flag or all paths have accepted file extensions.
-
 		// TODO write basic check for reduduncy. I.E converting gff to gff, etc.
 
 		// declaring wait group outside loop

--- a/poly/commands.go
+++ b/poly/commands.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -33,6 +34,8 @@ TTFN,
 Tim
 
 ******************************************************************************/
+
+var errIllegalFlag error = errors.New("the '-i' flag can only be used with pipes")
 
 /******************************************************************************
 
@@ -71,6 +74,9 @@ func convertCommand(c *cli.Context) error {
 		fmt.Fprint(c.App.Writer, string(output))
 
 	} else {
+		if c.String("i") != "" {
+			return errIllegalFlag
+		}
 
 		// gets glob pattern matches to determine which files to use.
 		matches := getMatches(c)
@@ -141,6 +147,9 @@ func hashCommand(c *cli.Context) error {
 		printHash(c, hash, "-")
 
 	} else {
+		if c.String("i") != "" {
+			return errIllegalFlag
+		}
 
 		// gets glob pattern matches to determine which files to use.
 		matches := getMatches(c)

--- a/poly/commands.go
+++ b/poly/commands.go
@@ -35,7 +35,7 @@ Tim
 
 ******************************************************************************/
 
-var errIllegalFlag error = errors.New("the '-i' flag can only be used with pipes")
+var errIllegalInputFlag error = errors.New("the '-i' flag can only be used with pipes")
 
 /******************************************************************************
 
@@ -75,7 +75,7 @@ func convertCommand(c *cli.Context) error {
 
 	} else {
 		if c.String("i") != "" {
-			return errIllegalFlag
+			return errIllegalInputFlag
 		}
 
 		// gets glob pattern matches to determine which files to use.
@@ -148,7 +148,7 @@ func hashCommand(c *cli.Context) error {
 
 	} else {
 		if c.String("i") != "" {
-			return errIllegalFlag
+			return errIllegalInputFlag
 		}
 
 		// gets glob pattern matches to determine which files to use.

--- a/poly/commands.go
+++ b/poly/commands.go
@@ -90,7 +90,7 @@ func convertCommand(c *cli.Context) error {
 
 			// executing Go routine.
 			go func(match string) {
-				sequence := fileParser(c, match)
+				sequence := parseExt(match)
 				writeFile(c, sequence, match)
 				// decrementing wait group.
 				wg.Done()
@@ -158,7 +158,7 @@ func hashCommand(c *cli.Context) error {
 
 			// executing Go routine.
 			go func(match string) {
-				sequence := fileParser(c, match)
+				sequence := parseExt(match)
 				hash, _ := sequence.Hash()
 				printHash(c, hash, match)
 
@@ -270,25 +270,6 @@ func uniqueNonEmptyElementsOf(s []string) []string {
 
 	return us
 
-}
-
-// function to parse whatever file is at a matched path.
-func fileParser(c *cli.Context, match string) poly.Sequence {
-	extension := filepath.Ext(match)
-	var sequence poly.Sequence
-
-	// determining which reader to use and parse into Sequence struct.
-	if extension == ".gff" || c.String("i") == "gff" {
-		sequence = poly.ReadGff(match)
-	} else if extension == ".gbk" || extension == ".gb" || c.String("i") == "gbk" || c.String("i") == "gb" {
-		sequence = poly.ReadGbk(match)
-	} else if extension == ".json" || c.String("i") == "json" {
-		sequence = poly.ReadJSON(match)
-	} else if extension == ".fasta" || c.String("i") == "fasta" {
-		sequence = poly.ReadFASTA(match)
-	}
-	// TODO put default error handling here.
-	return sequence
 }
 
 func buildStdOut(c *cli.Context, sequence poly.Sequence) []byte {

--- a/poly/commands_test.go
+++ b/poly/commands_test.go
@@ -261,7 +261,7 @@ func TestInputParameterForConvertErrorsIfNotPipe(t *testing.T) {
 	args := append(os.Args[0:1], "convert", "-i", "json", "../data/puc19.gbk")
 	err := app.Run(args)
 
-	if err != errIllegalFlag {
+	if err != errIllegalInputFlag {
 		t.Fatal("passing '-i' should throw an error if we are not reading from a pipe")
 	}
 }
@@ -271,7 +271,7 @@ func TestInputParameterForHashErrorsIfNotPipe(t *testing.T) {
 	args := append(os.Args[0:1], "hash", "-i", "json", "../data/puc19.gbk")
 	err := app.Run(args)
 
-	if err != errIllegalFlag {
+	if err != errIllegalInputFlag {
 		t.Fatal("passing '-i' should throw an error if we are not reading from a pipe")
 	}
 }

--- a/poly/commands_test.go
+++ b/poly/commands_test.go
@@ -255,5 +255,23 @@ func TestHashPipe(t *testing.T) {
 	if hashOutputString != testHashString {
 		t.Errorf("TestHashPipe has failed. Returned %q, want %q", hashOutputString, puc19GbkBlake3Hash)
 	}
+}
+func TestInputParameterForConvertErrorsIfNotPipe(t *testing.T) {
+	app := application()
+	args := append(os.Args[0:1], "convert", "-i", "json", "../data/puc19.gbk")
+	err := app.Run(args)
 
+	if err != errIllegalFlag {
+		t.Fatal("passing '-i' should throw an error if we are not reading from a pipe")
+	}
+}
+
+func TestInputParameterForHashErrorsIfNotPipe(t *testing.T) {
+	app := application()
+	args := append(os.Args[0:1], "hash", "-i", "json", "../data/puc19.gbk")
+	err := app.Run(args)
+
+	if err != errIllegalFlag {
+		t.Fatal("passing '-i' should throw an error if we are not reading from a pipe")
+	}
 }

--- a/poly/main.go
+++ b/poly/main.go
@@ -95,7 +95,7 @@ func application() *cli.App {
 					&cli.StringFlag{
 						Name:  "i",
 						Value: "",
-						Usage: "Specify file input type. Options are Gff, gbk/gb, and json. Defaults to none.",
+						Usage: "Specify file input type. Options are gff, gbk/gb, fasta, and json. Defaults to none. For use with pipes.",
 					},
 				},
 				// where we provide the actual function that is called by the subcommand.

--- a/poly/main.go
+++ b/poly/main.go
@@ -50,6 +50,15 @@ func run(args []string) {
 
 // application is a function that defines instances of our app. it's where we template commands and where initial arg parsing occurs.
 func application() *cli.App {
+	inputFlag := cli.StringFlag{
+		Name:  "i",
+		Usage: "Specify file input type. Options are gff, gbk/gb, fasta, and json. For use with pipes.",
+	}
+	outputFlag := cli.StringFlag{
+		Name:  "o",
+		Value: "json",
+		Usage: "Specify file output type or path. Defaults to json.",
+	}
 
 	app := &cli.App{
 		Name:  "poly",
@@ -57,21 +66,12 @@ func application() *cli.App {
 
 		// This is where you define global flags. Each sub command can also have its own flags that overide globals
 		Flags: []cli.Flag{
-
 			&cli.BoolFlag{
 				Name:  "y",
 				Usage: "Answers yes for all confirmations before doing something possibly destructive.",
 			},
-
-			&cli.StringFlag{
-				Name:  "i",
-				Usage: "Specify file input type or input path.",
-			},
-
-			&cli.StringFlag{
-				Name:  "o",
-				Usage: "Specify file output type or output path.",
-			},
+			&inputFlag,
+			&outputFlag,
 		},
 
 		// This is where you start defining subcommands there's a lot of spacing to enhance readability since these nested brackets can be a little much.
@@ -85,18 +85,8 @@ func application() *cli.App {
 
 				// defining flags for this specific sub command
 				Flags: []cli.Flag{
-
-					&cli.StringFlag{
-						Name:  "o",
-						Value: "json",
-						Usage: "Specify file output type or path. Defaults to json.",
-					},
-
-					&cli.StringFlag{
-						Name:  "i",
-						Value: "",
-						Usage: "Specify file input type. Options are gff, gbk/gb, fasta, and json. Defaults to none. For use with pipes.",
-					},
+					&inputFlag,
+					&outputFlag,
 				},
 				// where we provide the actual function that is called by the subcommand.
 				Action: func(c *cli.Context) error {
@@ -111,12 +101,7 @@ func application() *cli.App {
 				Usage:   "Hash a sequence while accounting for circularity using SeqhashV1.",
 
 				Flags: []cli.Flag{
-
-					&cli.StringFlag{
-						Name:  "i",
-						Value: "",
-						Usage: "Specify file input type. For use with pipes.",
-					},
+					&inputFlag,
 				},
 				Action: func(c *cli.Context) error {
 					err := hashCommand(c)

--- a/poly/main.go
+++ b/poly/main.go
@@ -114,7 +114,7 @@ func application() *cli.App {
 
 					&cli.StringFlag{
 						Name:  "i",
-						Value: "json",
+						Value: "",
 						Usage: "Specify file input type. For use with pipes.",
 					},
 				},


### PR DESCRIPTION
# why

Thinking about this: `// TODO write basic check to see if input flag or all paths have accepted file`

Noticed, the weird logic of `fileParser` is probably the reason behind this TODO:

`poly convert -i gbk file.gff` will parse correctly, but `poly convert -i gff file.gbk` will error. (assuming the file extensions are correct).

This PR proposes that the `-i` should only be used when the file is being piped: `cat data/bsub.gbk | poly c -i gbk -o json > test.json`

# how

delete `fileParse`, replace calls to it with `parseExt`.

This has the added benefit of increasing test coverage, since `fileParse` is not in any tests, while `parseExt` in only in tests. 

# question

how should passing `-i` be handled when the input source is not a pipe? 

Currently it is ignored, but probably should throw an error. Unsure how much this repo follows the "fail fast and loudly" philosophy though.