### PR TITLE
Enables Dev Container #117

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.166.1/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version: bionic, focal
+ARG VARIANT="focal"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && sudo apt-get update \
+  && sudo apt-get -y install golang
+
+RUN go get -v golang.org/x/tools/gopls
+RUN go get -u github.com/lukehoban/go-outline
+RUN go get -u github.com/uudashr/gopkgs/cmd/gopkgs
+RUN go get github.com/go-delve/delve/cmd/dlv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.166.1/containers/ubuntu
+{
+  "name": "poly - Ubuntu",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick an Ubuntu version: focal, bionic
+    "args": { "VARIANT": "focal" }
+  },
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": ["golang.go", "ms-vsliveshare.vsliveshare-pack","redhat.vscode-yaml","yzhang.markdown-all-in-one","premparihar.gotestexplorer","github.vscode-pull-request-github","streetsidesoftware.code-spell-checker","eamodio.gitlens"]
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "uname -a",
+
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  // "remoteUser": "vscode"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["golang.go", "ms-vsliveshare.vsliveshare-pack","redhat.vscode-yaml","yzhang.markdown-all-in-one","premparihar.gotestexplorer","github.vscode-pull-request-github","streetsidesoftware.code-spell-checker","eamodio.gitlens"]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,14 @@ For something that is bigger than a one or two line fix:
 3. Do the changes in your fork's branch.
 4. Send a pull request.
 
+## Virtual Environments and Development Containers 
+
+In order to simplify the development experience, and environment setup, the poly Github repository comes packaged to support *Github CodeSpaces* and [*VSCode Development Containers*](https://code.visualstudio.com/docs/remote/containers#_getting-started). *Github CodeSpaces* will give you ability to spin up a Github hosted instance of Ubuntu that would allow you run, test, develop poly from the browser. *VSCode Development Containers* in turn will allow your installation of VSCode to spin up a docker instance of Ubuntu on your computer and automatically mount your code onto it so that you continue developing on this docker instance that has all the required development environment setup. 
+
+## Recommended Plugins
+
+Whether you're a beginner with Go or you're an experienced developer, You should see the suggestions popup automatically when you goto the *Plugins* tab in VSCode. Using these plugins can help accelerate the development experience and also allow you to work more collaboratively with other poly developers.
+
 # How to report a bug
 
 ### Security disclosures
@@ -105,6 +113,10 @@ For non-security bug reports please [submit it using this template!](https://git
 # How to suggest a feature or enhancement
 
 If you want to suggest a feature it's as easy as filling out this [issue template](https://github.com/TimothyStiles/poly/issues/new?assignees=&labels=&template=feature_request.md&title=), but before you do please [check to see if it's already been suggested!](https://github.com/TimothyStiles/poly/labels/enhancement)
+
+# How add a recommended VSCode Plugin
+
+Poly comes with a set of recommended plugins for VSCode. If you have suggestions that will simplify life for the poly dev community, consider doing a pull-request after modifying `.vscode/extensions.json`. 
 
 # In closing
 


### PR DESCRIPTION
Added vscode dev container settings. Should install the go package a couple of other vscode plugins. Currently, the dev container image uses a Ubuntu Focal Container and installs golang using the latest apt package `golang`.

This dev container also installs the following plugins:
1. `golang.go`
2. `ms-vsliveshare.vsliveshare-pack`
3. `redhat.vscode-yaml`
4. `yzhang.markdown-all-in-one`
5. `premparihar.gotestexplorer`
6. `github.vscode-pull-request-github`
7. `streetsidesoftware.code-spell-checker`
8. `eamodio.gitlens`