### PR TITLE
Added concurrent parsing feature for genbank files

### DIFF
--- a/cmd/poly/commands_test.go
+++ b/cmd/poly/commands_test.go
@@ -62,7 +62,7 @@ func TestConvertPipe(t *testing.T) {
 		baseTestSequence := parseExt(match)
 		pipeOutputTestSequence := polyjson.Parse(writeBuffer.Bytes())
 
-		if diff := cmp.Diff(baseTestSequence, pipeOutputTestSequence, cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence")); diff != "" {
+		if diff := cmp.Diff(baseTestSequence, pipeOutputTestSequence, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "MD5")}...); diff != "" {
 			t.Errorf(" mismatch converting from %q to json (-want +got):\n%s", extension, diff)
 		}
 	}
@@ -92,7 +92,7 @@ func TestConvertIO(t *testing.T) {
 
 		pipeOutputTestSequence := parseFlag(writeBuffer.Bytes(), extension)
 
-		if diff := cmp.Diff(baseTestSequence, pipeOutputTestSequence, cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence")); diff != "" {
+		if diff := cmp.Diff(baseTestSequence, pipeOutputTestSequence, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "MD5")}...); diff != "" {
 			t.Errorf(" mismatch reading and writing %q (-want +got):\n%s", extension, diff)
 		}
 	}
@@ -121,7 +121,7 @@ func TestConvertWriteFile(t *testing.T) {
 		outputSequence := parseExt(testOutputPath)
 		os.Remove(testOutputPath)
 
-		if diff := cmp.Diff(baseTestSequence, outputSequence, cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence")); diff != "" {
+		if diff := cmp.Diff(baseTestSequence, outputSequence, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "MD5")}...); diff != "" {
 			t.Errorf(" mismatch reading and writing %q (-want +got):\n%s", extension, diff)
 		}
 	}

--- a/cmd/poly/commands_test.go
+++ b/cmd/poly/commands_test.go
@@ -62,7 +62,7 @@ func TestConvertPipe(t *testing.T) {
 		baseTestSequence := parseExt(match)
 		pipeOutputTestSequence := polyjson.Parse(writeBuffer.Bytes())
 
-		if diff := cmp.Diff(baseTestSequence, pipeOutputTestSequence, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "MD5")}...); diff != "" {
+		if diff := cmp.Diff(baseTestSequence, pipeOutputTestSequence, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "CheckSum")}...); diff != "" {
 			t.Errorf(" mismatch converting from %q to json (-want +got):\n%s", extension, diff)
 		}
 	}
@@ -92,7 +92,7 @@ func TestConvertIO(t *testing.T) {
 
 		pipeOutputTestSequence := parseFlag(writeBuffer.Bytes(), extension)
 
-		if diff := cmp.Diff(baseTestSequence, pipeOutputTestSequence, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "MD5")}...); diff != "" {
+		if diff := cmp.Diff(baseTestSequence, pipeOutputTestSequence, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "CheckSum")}...); diff != "" {
 			t.Errorf(" mismatch reading and writing %q (-want +got):\n%s", extension, diff)
 		}
 	}
@@ -121,7 +121,7 @@ func TestConvertWriteFile(t *testing.T) {
 		outputSequence := parseExt(testOutputPath)
 		os.Remove(testOutputPath)
 
-		if diff := cmp.Diff(baseTestSequence, outputSequence, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "MD5")}...); diff != "" {
+		if diff := cmp.Diff(baseTestSequence, outputSequence, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "CheckSum")}...); diff != "" {
 			t.Errorf(" mismatch reading and writing %q (-want +got):\n%s", extension, diff)
 		}
 	}

--- a/io/genbank/genbank.go
+++ b/io/genbank/genbank.go
@@ -781,18 +781,14 @@ func ParseMulti(file []byte) []poly.Sequence {
 // the genbank ftp dumps. These files have 10 line headers, which are entirely
 // removed
 func ParseFlat(file []byte) []poly.Sequence {
-
-	gbk := string(file)
-
-	// This code removes the header, which is 10 lines long. This is inefficient
-	// and gets rid of the data in the header, which may be useful for some
-	// application. Header data is not needed to parse the Genbank files, though
-	gbkWithoutHeader := []byte(strings.Join(strings.Split(gbk, "\n")[10:], "\n"))
-
-	// Pass gbkWithoutHeader to ParseMulti, which should handle
-	// the rest of the parsing just fine
-	sequences := ParseMulti(gbkWithoutHeader)
-	return sequences
+	r := bytes.NewReader(file)
+	sequences := make(chan poly.Sequence, 1000) // A buffer is used so that the functions run as it is appending
+	go ParseFlatConcurrent(r, sequences)
+	var outputGenbanks []poly.Sequence
+	for sequence := range sequences {
+		outputGenbanks = append(outputGenbanks, sequence)
+	}
+	return outputGenbanks
 }
 
 // ReadMulti reads multiple genbank files from a single file
@@ -831,7 +827,7 @@ Genbank Concurrent specific IO related things begin here.
 
 ******************************************************************************/
 
-// ParseConcurrentString concurrently parses a given Genbank file in an io.Reader into a channel of poly.Sequence.
+// ParseConcurrent concurrently parses a given multi-Genbank file in an io.Reader into a channel of poly.Sequence.
 func ParseConcurrent(r io.Reader, sequences chan<- poly.Sequence) {
 	var gbkStr string
 	var gbk poly.Sequence
@@ -853,6 +849,18 @@ func ParseConcurrent(r io.Reader, sequences chan<- poly.Sequence) {
 		}
 	}
 	close(sequences)
+}
+
+// ParseFlatConcurrent concurrently parses a given flat-Genbank file in an io.Reader into a channel of poly.Sequnce.
+func ParseFlatConcurrent(r io.Reader, sequences chan<- poly.Sequence) {
+	// Start a new reader
+	reader := bufio.NewReader(r)
+	// Read 10 lines, or the header of a flat file
+	// Header data is not needed to parse the Genbank files, though it may contain useful information.
+	for i := 0; i < 10; i++ {
+		_, _, _ = reader.ReadLine()
+	}
+	go ParseConcurrent(reader, sequences)
 }
 
 /******************************************************************************

--- a/io/genbank/genbank.go
+++ b/io/genbank/genbank.go
@@ -38,7 +38,7 @@ func Parse(file []byte) poly.Sequence {
 	// Create sequence struct
 	sequence := poly.Sequence{}
 
-	// Add the SHA256 hash to sequence.SHA256
+	// Add the MD5 hash to sequence.MD5
 	sequence.MD5 = md5.Sum(file)
 
 	for numLine := 0; numLine < len(lines); numLine++ {
@@ -767,7 +767,7 @@ Genbank Flat specific IO related things begin here.
 // ParseMulti parses multiple Genbank files in a byte array to multiple sequences
 func ParseMulti(file []byte) []poly.Sequence {
 	r := bytes.NewReader(file)
-	sequences := make(chan poly.Sequence, 1000) // A buffer is used so that the functions run as it is appending
+	sequences := make(chan poly.Sequence)
 	go ParseConcurrent(r, sequences)
 
 	var outputGenbanks []poly.Sequence
@@ -782,7 +782,7 @@ func ParseMulti(file []byte) []poly.Sequence {
 // removed
 func ParseFlat(file []byte) []poly.Sequence {
 	r := bytes.NewReader(file)
-	sequences := make(chan poly.Sequence, 1000) // A buffer is used so that the functions run as it is appending
+	sequences := make(chan poly.Sequence)
 	go ParseFlatConcurrent(r, sequences)
 	var outputGenbanks []poly.Sequence
 	for sequence := range sequences {

--- a/io/genbank/genbank.go
+++ b/io/genbank/genbank.go
@@ -4,10 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
-	"crypto/md5"
 	"io"
 	"io/ioutil"
 	"log"
+	"lukechampine.com/blake3"
 	"regexp"
 	"strconv"
 	"strings"
@@ -38,8 +38,8 @@ func Parse(file []byte) poly.Sequence {
 	// Create sequence struct
 	sequence := poly.Sequence{}
 
-	// Add the MD5 hash to sequence.MD5
-	sequence.MD5 = md5.Sum(file)
+	// Add the CheckSum to sequence (blake3)
+	sequence.CheckSum = blake3.Sum256(file)
 
 	for numLine := 0; numLine < len(lines); numLine++ {
 		line := lines[numLine]

--- a/io/genbank/genbank_test.go
+++ b/io/genbank/genbank_test.go
@@ -73,7 +73,7 @@ func TestGbkIO(t *testing.T) {
 	Write(gbk, tmpGbkFilePath)
 
 	writeTestGbk := Read(tmpGbkFilePath)
-	if diff := cmp.Diff(gbk, writeTestGbk, cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence")); diff != "" {
+	if diff := cmp.Diff(gbk, writeTestGbk, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "MD5")}...); diff != "" {
 		t.Errorf("Parsing the output of Build() does not produce the same output as parsing the original file read with Read(). Got this diff:\n%s", diff)
 	}
 
@@ -108,7 +108,7 @@ func TestGbkLocationStringBuilder(t *testing.T) {
 	testInputGbk := Read("../../data/sample.gbk")
 	testOutputGbk := Read(tmpGbkFilePath)
 
-	if diff := cmp.Diff(testInputGbk, testOutputGbk, cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence")); diff != "" {
+	if diff := cmp.Diff(testInputGbk, testOutputGbk, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "MD5")}...); diff != "" {
 		t.Errorf("Issue with partial location building. Parsing the output of Build() does not produce the same output as parsing the original file read with Read(). Got this diff:\n%s", diff)
 	}
 }
@@ -133,7 +133,7 @@ func TestGbLocationStringBuilder(t *testing.T) {
 	testInputGb := Read("../../data/t4_intron.gb")
 	testOutputGb := Read(tmpGbFilePath)
 
-	if diff := cmp.Diff(testInputGb, testOutputGb, cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence")); diff != "" {
+	if diff := cmp.Diff(testInputGb, testOutputGb, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "MD5")}...); diff != "" {
 		t.Errorf("Issue with either Join or complement location building. Parsing the output of Build() does not produce the same output as parsing the original file read with Read(). Got this diff:\n%s", diff)
 	}
 }

--- a/io/genbank/genbank_test.go
+++ b/io/genbank/genbank_test.go
@@ -73,7 +73,7 @@ func TestGbkIO(t *testing.T) {
 	Write(gbk, tmpGbkFilePath)
 
 	writeTestGbk := Read(tmpGbkFilePath)
-	if diff := cmp.Diff(gbk, writeTestGbk, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "MD5")}...); diff != "" {
+	if diff := cmp.Diff(gbk, writeTestGbk, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "CheckSum")}...); diff != "" {
 		t.Errorf("Parsing the output of Build() does not produce the same output as parsing the original file read with Read(). Got this diff:\n%s", diff)
 	}
 
@@ -108,7 +108,7 @@ func TestGbkLocationStringBuilder(t *testing.T) {
 	testInputGbk := Read("../../data/sample.gbk")
 	testOutputGbk := Read(tmpGbkFilePath)
 
-	if diff := cmp.Diff(testInputGbk, testOutputGbk, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "MD5")}...); diff != "" {
+	if diff := cmp.Diff(testInputGbk, testOutputGbk, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "CheckSum")}...); diff != "" {
 		t.Errorf("Issue with partial location building. Parsing the output of Build() does not produce the same output as parsing the original file read with Read(). Got this diff:\n%s", diff)
 	}
 }
@@ -133,7 +133,7 @@ func TestGbLocationStringBuilder(t *testing.T) {
 	testInputGb := Read("../../data/t4_intron.gb")
 	testOutputGb := Read(tmpGbFilePath)
 
-	if diff := cmp.Diff(testInputGb, testOutputGb, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "MD5")}...); diff != "" {
+	if diff := cmp.Diff(testInputGb, testOutputGb, []cmp.Option{cmpopts.IgnoreFields(poly.Feature{}, "ParentSequence"), cmpopts.IgnoreFields(poly.Sequence{}, "CheckSum")}...); diff != "" {
 		t.Errorf("Issue with either Join or complement location building. Parsing the output of Build() does not produce the same output as parsing the original file read with Read(). Got this diff:\n%s", diff)
 	}
 }

--- a/io/gff/gff.go
+++ b/io/gff/gff.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"log"
+	"lukechampine.com/blake3"
 	"regexp"
 	"sort"
 	"strconv"
@@ -17,6 +18,9 @@ func Parse(file []byte) poly.Sequence {
 
 	gff := string(file)
 	sequence := poly.Sequence{}
+
+	// Add the CheckSum to sequence (blake3)
+	sequence.CheckSum = blake3.Sum256(file)
 
 	lines := strings.Split(gff, "\n")
 	metaString := lines[0:2]

--- a/poly.go
+++ b/poly.go
@@ -103,6 +103,7 @@ type Sequence struct {
 	SequenceHashFunction string    `json:"hash_function"`
 	Sequence             string    `json:"sequence"`
 	Features             []Feature `json:"features"`
+	MD5                  [16]byte  `json:"hash"` //SHA256 checksum
 }
 
 // AddFeature is the canonical way to add a Feature into a Sequence struct. Appending a Feature struct directly to Sequence.Feature's will break .GetSequence() method.

--- a/poly.go
+++ b/poly.go
@@ -103,7 +103,7 @@ type Sequence struct {
 	SequenceHashFunction string    `json:"hash_function"`
 	Sequence             string    `json:"sequence"`
 	Features             []Feature `json:"features"`
-	MD5                  [16]byte  `json:"hash"` //SHA256 checksum
+	MD5                  [16]byte  `json:"hash"` //MD5 checksum
 }
 
 // AddFeature is the canonical way to add a Feature into a Sequence struct. Appending a Feature struct directly to Sequence.Feature's will break .GetSequence() method.

--- a/poly.go
+++ b/poly.go
@@ -103,7 +103,7 @@ type Sequence struct {
 	SequenceHashFunction string    `json:"hash_function"`
 	Sequence             string    `json:"sequence"`
 	Features             []Feature `json:"features"`
-	MD5                  [16]byte  `json:"hash"` //MD5 checksum
+	CheckSum             [32]byte  `json:"checkSum"` // blake3 checksum of the parsed file itself. Useful for if you want to check if incoming genbank/gff files are different.
 }
 
 // AddFeature is the canonical way to add a Feature into a Sequence struct. Appending a Feature struct directly to Sequence.Feature's will break .GetSequence() method.


### PR DESCRIPTION
This adds simple concurrent parsing for genbank files. I added two functions:

1. ParseConcurrent: Parses a mutli-genbank file into a channel
2. ParseFlatConcurrent: Parses a flat-genbank file into a channel

I also added an MD5 hash into the Sequence struct. This will be used in allbase to see if genbank files should be updated.