### PR TITLE
Add GcContent function to barcodes

### DIFF
--- a/primers/primers.go
+++ b/primers/primers.go
@@ -289,8 +289,8 @@ func CreateBarcodes(length int, maxSubSequence int) []string {
 
 // CreateBarcodesGcRange creates a list of barcodes within a given GC range.
 func CreateBarcodesGcRange(length int, maxSubSequence int, minGcContent float64, maxGcContent float64) []string {
-	gcBarcodeFunc := func(s string) bool {
-		gcContent := checks.GcContent(s)
+	gcBarcodeFunc := func(barcodeToCheck string) bool {
+		gcContent := checks.GcContent(barcodeToCheck)
 		if gcContent < minGcContent || gcContent > maxGcContent {
 			return false
 		}

--- a/primers/primers.go
+++ b/primers/primers.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strings"
 
+	"github.com/TimothyStiles/poly/checks"
 	"github.com/TimothyStiles/poly/transform"
 )
 
@@ -284,4 +285,16 @@ func CreateBarcodesWithBannedSequences(length int, maxSubSequence int, bannedSeq
 // CreateBarcodes is a simplified version of CreateBarcodesWithBannedSequences with sane defaults.
 func CreateBarcodes(length int, maxSubSequence int) []string {
 	return CreateBarcodesWithBannedSequences(length, maxSubSequence, []string{}, []func(string) bool{})
+}
+
+// CreateBarcodesGcRange creates a list of barcodes within a given GC range.
+func CreateBarcodesGcRange(length int, maxSubSequence int, minGcContent float64, maxGcContent float64) []string {
+	gcBarcodeFunc := func(s string) bool {
+		gcContent := checks.GcContent(s)
+		if gcContent < minGcContent || gcContent > maxGcContent {
+			return false
+		}
+		return true
+	}
+	return CreateBarcodesWithBannedSequences(length, maxSubSequence, []string{}, []func(string) bool{gcBarcodeFunc})
 }

--- a/primers/primers_test.go
+++ b/primers/primers_test.go
@@ -105,6 +105,13 @@ func ExampleCreateBarcodes() {
 	// Output: AAAATAAAGAAACAATTAAT
 }
 
+func ExampleCreateBarcodesGcRange() {
+	barcodes := CreateBarcodesGcRange(20, 4, .25, .75)
+
+	fmt.Println(barcodes[0])
+	// Output: GAAACAATTAATGAATCAAG
+}
+
 func TestCreateBarcode(t *testing.T) {
 	testFunc := func(s string) bool {
 		return !strings.Contains(s, "GGCCGCGCCCC")


### PR DESCRIPTION
This PR adds `CreateBarcodesGcRange` into `primers`. It gives users a more intuitive interface for generating barcodes that are within a given GC content, which is important when designing PCR primers and the like for barcoding sequences.

100% test coverage maintained.