### PR TITLE
Handle invalid amino acids in codon optimization

### DIFF
--- a/synthesis/codon/codon.go
+++ b/synthesis/codon/codon.go
@@ -59,6 +59,14 @@ var errEmtpyCodonTable error = errors.New("empty codon table")
 var errEmtpyAminoAcidString error = errors.New("empty amino acid string")
 var errEmtpySequenceString error = errors.New("empty sequence string")
 
+type InvalidAminoAcidError struct {
+	AminoAcid rune
+}
+
+func (e InvalidAminoAcidError) Error() string {
+	return fmt.Sprintf("amino acid %q is missing from codon table", e.AminoAcid)
+}
+
 // Codon holds information for a codon triplet in a struct
 type Codon struct {
 	Triplet string `json:"triplet"`
@@ -126,8 +134,11 @@ func Optimize(aminoAcids string, codonTable Table) (string, error) {
 	}
 
 	for _, aminoAcid := range aminoAcids {
-		aminoAcidString := string(aminoAcid)
-		codons.WriteString(codonChooser[aminoAcidString].Pick().(string))
+		chooser, ok := codonChooser[string(aminoAcid)]
+		if !ok {
+			return "", InvalidAminoAcidError{aminoAcid}
+		}
+		codons.WriteString(chooser.Pick().(string))
 	}
 	return codons.String(), nil
 }

--- a/synthesis/codon/codon.go
+++ b/synthesis/codon/codon.go
@@ -59,6 +59,7 @@ var errEmtpyCodonTable error = errors.New("empty codon table")
 var errEmtpyAminoAcidString error = errors.New("empty amino acid string")
 var errEmtpySequenceString error = errors.New("empty sequence string")
 
+// InvalidAminoAcidError is returned when an input protein sequence contains an invalid amino acid.
 type InvalidAminoAcidError struct {
 	AminoAcid rune
 }

--- a/synthesis/codon/codon_test.go
+++ b/synthesis/codon/codon_test.go
@@ -88,6 +88,20 @@ func TestOptimizeErrorsOnEmptyAminoAcidString(t *testing.T) {
 		t.Error("Optimize should return an error if given an empty amino acid string")
 	}
 }
+func TestOptimizeErrorsOnInvalidAminoAcid(t *testing.T) {
+	aminoAcids := "TOP"
+	table := GetCodonTable(1) // does not contain 'O'
+	_, err := Optimize(aminoAcids, table)
+
+	want := InvalidAminoAcidError{'O'}
+	got, isInvalidAminoAcidError := err.(InvalidAminoAcidError)
+	if !isInvalidAminoAcidError {
+		t.Errorf("Optimize should return an InvalidAminoAcidError, got %T", got)
+	}
+	if got != want {
+		t.Errorf("Optimize should return an InvalidAminoAcidError for %q, got %q", want.AminoAcid, got.AminoAcid)
+	}
+}
 
 func TestGetCodonFrequency(t *testing.T) {
 


### PR DESCRIPTION
This PR addresses issue #201 by updating `codon.Optimize` to gracefully handle protein sequences where at least one amino acid is missing from the codon table. A new custom error was added to enable the caller to find the offending amino acid.

Alternatively, `Optimize` could validate the protein sequence before building the codon chooser map. That would require a slightly bigger change to this function and would slow down the execution for valid inputs. On the upside, it could be beneficial to fail faster and to return the full set of invalid amino acids (as opposed to only the first one). Please let me know if that would be preferable.