### PR TITLE
bump linter runner gh action and add linter config

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v2.5.2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: latest
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,35 @@
+run:
+  timeout: 1m
+  skip-dirs:
+    - data
+linters:
+  enable:
+    - bodyclose
+    ##- dogsled
+    - dupl
+    #- exhaustivestruct
+    - exportloopref
+    #- funlen
+    - gochecknoinits
+    ##- goconst
+    ##- gocritic
+    ##- gocyclo
+    ##- gofmt
+    ##- goimports
+    #- gomnd
+    - goprintffuncname
+    ##- gosec
+    #- lll
+    ##- misspell
+    - nakedret
+    - nilnil
+    - noctx
+    - nolintlint
+    ##- stylecheck
+    ##- unconvert
+    ##- unparam
+    ##- whitespace
+#linters-settings:
+#  stylecheck:
+#    # https://staticcheck.io/docs/options#checks
+#    checks: ["all", "-ST1005"]

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+cd "$(dirname "$0")"/..
+
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+golangci-lint run


### PR DESCRIPTION
 @TimothyStiles 
i have updated the GH action to use the latest golangci-lint-action as well as bumped the config to always use the latest release of golangci-lint.

Added .golangci.yml for linter configurations. Have initially enabled a bunch of linters that i have found useful and commented out all linters that fail atm for a gradual rollout. Please feel free to update the list of additional linters.

added lint.sh to make it simpler to run the latest linter locally.