### PR TITLE
Increase coverage for the variants package

### DIFF
--- a/transform/variants/variants.go
+++ b/transform/variants/variants.go
@@ -53,24 +53,25 @@ func AllVariantsIUPAC(seq string) ([]string, error) {
 	}
 	return seqVariants, nil
 }
-func cartRune(inList ...[]rune) [][]rune {
-	// An iteratitive approach to calculate Cartesian product of two or more lists
+
+func cartRune(inLists ...[]rune) [][]rune {
+	// An iterative approach to calculate Cartesian product of two or more lists
 	// Adapted from https://rosettacode.org/wiki/Cartesian_product_of_two_or_more_lists
 	// supposedly "minimizes allocations and computes and fills the result sequentially"
 
 	var possibleVariants int = 1 // a counter used to determine the possible number of variants
-	for _, inList := range inList {
+	for _, inList := range inLists {
 		possibleVariants *= len(inList)
 	}
 	if possibleVariants == 0 {
 		return nil // in the future this could be part of an error return?
 	}
-	allVariants := make([][]rune, possibleVariants)              // this is the 2D slice where all variants will be stored
-	variantHolders := make([]rune, possibleVariants*len(inList)) // this is an empty slice with a length totaling the size of all input characters
-	variantChoices := make([]int, len(inList))                   // these will be all the possible variants
+	allVariants := make([][]rune, possibleVariants)               // this is the 2D slice where all variants will be stored
+	variantHolders := make([]rune, possibleVariants*len(inLists)) // this is an empty slice with a length totaling the size of all input characters
+	variantChoices := make([]int, len(inLists))                   // these will be all the possible variants
 	start := 0
 	for variant := range allVariants {
-		end := start + len(inList) // define end point
+		end := start + len(inLists) // define end point
 		variantHolder := variantHolders[start:end]
 
 		allVariants[variant] = variantHolder
@@ -78,11 +79,11 @@ func cartRune(inList ...[]rune) [][]rune {
 		start = end // start at end point
 
 		for variantChoicesIndex, variantChoice := range variantChoices {
-			variantHolder[variantChoicesIndex] = inList[variantChoicesIndex][variantChoice]
+			variantHolder[variantChoicesIndex] = inLists[variantChoicesIndex][variantChoice]
 		}
 		for variantChoicesIndex := len(variantChoices) - 1; variantChoicesIndex >= 0; variantChoicesIndex-- {
 			variantChoices[variantChoicesIndex]++
-			if variantChoices[variantChoicesIndex] < len(inList[variantChoicesIndex]) {
+			if variantChoices[variantChoicesIndex] < len(inLists[variantChoicesIndex]) {
 				break
 			}
 			variantChoices[variantChoicesIndex] = 0

--- a/transform/variants/variants_test.go
+++ b/transform/variants/variants_test.go
@@ -1,30 +1,32 @@
-package variants_test
+package variants
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"testing"
 
-	"github.com/TimothyStiles/poly/transform/variants"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIUPAC(t *testing.T) {
 	testSeq := "ATN"
 	testVariants := []string{"ATG", "ATA", "ATT", "ATC"}
-	testVariantsIUPAC, err := variants.AllVariantsIUPAC(testSeq)
-	if err != nil {
-		log.Fatal(err)
-	}
+	testVariantsIUPAC, err := AllVariantsIUPAC(testSeq)
+	assert.Nil(t, err)
 
 	sort.Strings(testVariants)
 	sort.Strings(testVariantsIUPAC)
 
 	for index := range testVariants {
-		if testVariants[index] != testVariantsIUPAC[index] {
-			t.Errorf("IUPAC variant has changed on test 'allIUPAC('ATN')'. Got this:\n%s instead of \n%s", testVariantsIUPAC, testVariants)
-		}
+		assert.Equal(t, testVariants[index], testVariantsIUPAC[index], "IUPAC variant has changed")
 	}
+}
+
+func TestIUPAC_errors(t *testing.T) {
+	testSeq := "ATX"
+	seqVariants, err := AllVariantsIUPAC(testSeq)
+	assert.NotNil(t, err, "expected error for unsupported IUPAC character, got nil")
+	assert.Equal(t, seqVariants, []string{})
 }
 
 func ExampleAllVariantsIUPAC() {
@@ -32,8 +34,62 @@ func ExampleAllVariantsIUPAC() {
 	// and returns all iupac variants as output
 	mendelIUPAC := "ATGGARAAYGAYGARCTN"
 	// ambiguous IUPAC codes for most of the sequences that code for the protein MENDEL
-	mendelIUPACvariants, _ := variants.AllVariantsIUPAC(mendelIUPAC)
+	mendelIUPACvariants, _ := AllVariantsIUPAC(mendelIUPAC)
 	fmt.Println(mendelIUPACvariants)
 	// Output: [ATGGAGAATGATGAGCTG ATGGAGAATGATGAGCTA ATGGAGAATGATGAGCTT ATGGAGAATGATGAGCTC ATGGAGAATGATGAACTG ATGGAGAATGATGAACTA ATGGAGAATGATGAACTT ATGGAGAATGATGAACTC ATGGAGAATGACGAGCTG ATGGAGAATGACGAGCTA ATGGAGAATGACGAGCTT ATGGAGAATGACGAGCTC ATGGAGAATGACGAACTG ATGGAGAATGACGAACTA ATGGAGAATGACGAACTT ATGGAGAATGACGAACTC ATGGAGAACGATGAGCTG ATGGAGAACGATGAGCTA ATGGAGAACGATGAGCTT ATGGAGAACGATGAGCTC ATGGAGAACGATGAACTG ATGGAGAACGATGAACTA ATGGAGAACGATGAACTT ATGGAGAACGATGAACTC ATGGAGAACGACGAGCTG ATGGAGAACGACGAGCTA ATGGAGAACGACGAGCTT ATGGAGAACGACGAGCTC ATGGAGAACGACGAACTG ATGGAGAACGACGAACTA ATGGAGAACGACGAACTT ATGGAGAACGACGAACTC ATGGAAAATGATGAGCTG ATGGAAAATGATGAGCTA ATGGAAAATGATGAGCTT ATGGAAAATGATGAGCTC ATGGAAAATGATGAACTG ATGGAAAATGATGAACTA ATGGAAAATGATGAACTT ATGGAAAATGATGAACTC ATGGAAAATGACGAGCTG ATGGAAAATGACGAGCTA ATGGAAAATGACGAGCTT ATGGAAAATGACGAGCTC ATGGAAAATGACGAACTG ATGGAAAATGACGAACTA ATGGAAAATGACGAACTT ATGGAAAATGACGAACTC ATGGAAAACGATGAGCTG ATGGAAAACGATGAGCTA ATGGAAAACGATGAGCTT ATGGAAAACGATGAGCTC ATGGAAAACGATGAACTG ATGGAAAACGATGAACTA ATGGAAAACGATGAACTT ATGGAAAACGATGAACTC ATGGAAAACGACGAGCTG ATGGAAAACGACGAGCTA ATGGAAAACGACGAGCTT ATGGAAAACGACGAGCTC ATGGAAAACGACGAACTG ATGGAAAACGACGAACTA ATGGAAAACGACGAACTT ATGGAAAACGACGAACTC]
+}
 
+func ExampleAllVariantsIUPAC_error() {
+	// AllVariantsIUPAC takes a string as input
+	// and returns all iupac variants as output
+	mendelIUPAC := "ATGGARAAYGAYGARXYZ"
+	// ambiguous IUPAC codes for most of the sequences that code for the protein MENDEL
+	mendelIUPACvariants, _ := AllVariantsIUPAC(mendelIUPAC)
+	fmt.Println(mendelIUPACvariants)
+	// Output: []
+}
+
+func Test_cartRunes(t *testing.T) {
+	for _, tc := range []struct {
+		in  [][]rune
+		out [][]rune
+	}{
+		{
+			in: [][]rune{
+				{1, 2, 3},
+			},
+			out: [][]rune{
+				{1},
+				{2},
+				{3},
+			},
+		},
+		{
+			in:  [][]rune{nil},
+			out: nil,
+		},
+		{
+			in: [][]rune{
+				{'A', 'T', 'G'},
+				{'A', 'T', 'A', 'G'},
+			},
+			out: [][]rune{
+				{'A', 'A'},
+				{'A', 'T'},
+				{'A', 'A'},
+				{'A', 'G'},
+				{'T', 'A'},
+				{'T', 'T'},
+				{'T', 'A'},
+				{'T', 'G'},
+				{'G', 'A'},
+				{'G', 'T'},
+				{'G', 'A'},
+				{'G', 'G'},
+			},
+		},
+	} {
+		runes := cartRune(tc.in...)
+		assert.Equal(t, runes, tc.out)
+	}
 }


### PR DESCRIPTION
In this PR, I'm making a few small tweaks to the variants package, and I've increased test coverage to 100%

- Fix a typo for iteratitive -> iterative
- Rename the test package from variants_test to variants to permit testing of private function
- Increase test coverage to 100%
- Use the assert package to fail tests, as this is more succinct than if statements

If the changes here are acceptable, I can move on to increasing coverage in other packages.