### PR TITLE
created non-third party coverage badge.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,29 @@
+name: Build Coverage Badge
+
+on:
+  push:
+    branches:
+      - prime
+
+jobs:
+  coverage-badge:
+    name: Create Answer Badge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Generate coverage report
+        run: go test -v  -coverprofile=profile.cov ./...
+      - name: Parse overall coverage
+        run: coverage=$(go tool cover -func profile.cov | tail -1 | rev | cut -f 1 | rev) && echo "COVERAGE=$coverage" >> $GITHUB_ENV 
+      - name: Create the Badge
+        uses: schneegans/dynamic-badges-action@master
+        with:
+          auth: ${{ secrets.COVERAGE_GIST}}
+          gistID: e58f265655ac0acacdd1a38376ccd32a
+          filename: coverage.json
+          label: Coverage
+          message: ${{ env.COVERAGE }}
+          color: green

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/TimothyStiles/poly)](https://pkg.go.dev/github.com/TimothyStiles/poly)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/TimothyStiles/poly/blob/prime/LICENSE) 
 ![Tests](https://github.com/TimothyStiles/poly/workflows/Test/badge.svg)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/43dc1fb3572b7812865e/test_coverage)](https://codeclimate.com/github/TimothyStiles/poly/test_coverage)
+![Test Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/TimothyStiles/e58f265655ac0acacdd1a38376ccd32a/raw/coverage.json)
 
 Poly is a Go package for engineering organisms.
 


### PR DESCRIPTION
The old coverage badge was with code cov and completely unreliable. This new one is entirely through github actions and uses github gists to store information for badge generation. It should be far more stable and accurate.