### PR TITLE
Install Go Analysis Tools in Gitpod workspace

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,10 +20,12 @@ tasks:
       go install -v github.com/ramya-rao-a/go-outline@latest
       go install -v golang.org/x/tools/gopls@latest
       go install -v honnef.co/go/tools/cmd/staticcheck@latest
+      clear
 
   - name: Open Tutorial Directory   
     command: >
       gp ports await 23000 &&
+      clear &&
       if [ -n "$tutorial" ]; then cd ./tutorials && code -r . && clear; fi
 # there's a bug within gitpod's fork of VS code web that doesn't allow you to open both 
 # a directory and file from the command line at the same time.

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,15 +4,27 @@
 
 tasks:
   - name: Golang
-  - init: >
+    init: >
      go get && 
      go build ./... && 
      go test ./...
 
+  # https://github.com/golang/vscode-go/wiki/tools
+  - name: Install Go Analysis Tools
+    init: |
+      go install -v github.com/cweill/gotests/gotests@latest
+      go install -v github.com/fatih/gomodifytags@latest
+      go install -v github.com/go-delve/delve/cmd/dlv@latest
+      go install -v github.com/haya14busa/goplay/cmd/goplay@latest
+      go install -v github.com/josharian/impl@latest
+      go install -v github.com/ramya-rao-a/go-outline@latest
+      go install -v golang.org/x/tools/gopls@latest
+      go install -v honnef.co/go/tools/cmd/staticcheck@latest
+
   - name: Open Tutorial Directory   
     command: >
       gp ports await 23000 &&
-      if [ $tutorial == true ]; then cd ./tutorials && code -r . && clear; fi
+      if [ -n "$tutorial" ]; then cd ./tutorials && code -r . && clear; fi
 # there's a bug within gitpod's fork of VS code web that doesn't allow you to open both 
 # a directory and file from the command line at the same time.
 # See https://github.com/gitpod-io/gitpod/issues/13107


### PR DESCRIPTION
Without this, VS Code prompts to install `gopls`, `dlv`, etc. before setting a breakpoint + debugging a tutorial works.

I'm not sure if there's a more elegant way to run `Go: Install/Update Tools` (https://github.com/golang/vscode-go/wiki/tools) in the Command Palette instead.

Also simplified the check for `$tutorial`, as otherwise this line causes a syntax error when the variable isn't set at all.