### PR TITLE
Remove unnecessary conversions

### DIFF
--- a/io/genbank/genbank.go
+++ b/io/genbank/genbank.go
@@ -745,7 +745,7 @@ func parseLocus(locusString string) Locus {
 	locus.Name = filteredLocusSplit[1]
 
 	// sequence length and coding
-	baseSequenceLength := string(basePairRegex.FindString(locusString))
+	baseSequenceLength := basePairRegex.FindString(locusString)
 	if baseSequenceLength != "" {
 		splitBaseSequenceLength := strings.Split(strings.TrimSpace(baseSequenceLength), " ")
 		if len(splitBaseSequenceLength) == 2 {

--- a/io/gff/gff.go
+++ b/io/gff/gff.go
@@ -74,7 +74,7 @@ type Location struct {
 	SubLocations      []Location `json:"sub_locations"`
 }
 
-//AddFeature takes a feature and adds it to the Gff struct.
+// AddFeature takes a feature and adds it to the Gff struct.
 func (sequence *Gff) AddFeature(feature *Feature) error {
 	feature.ParentSequence = sequence
 	var featureCopy Feature = *feature
@@ -250,7 +250,7 @@ func Build(sequence Gff) ([]byte, error) {
 		featureEnd := strconv.Itoa(feature.Location.End)
 
 		featureScore := feature.Score
-		featureStrand := string(feature.Strand)
+		featureStrand := feature.Strand
 		featurePhase := feature.Phase
 		var featureAttributes string
 

--- a/synthesis/codon/codon.go
+++ b/synthesis/codon/codon.go
@@ -423,7 +423,7 @@ Keoni
 // ParseCodonJSON parses a codonTable JSON file.
 func ParseCodonJSON(file []byte) Table {
 	var codonTable codonTable
-	_ = json.Unmarshal([]byte(file), &codonTable)
+	_ = json.Unmarshal(file, &codonTable)
 	return codonTable
 }
 


### PR DESCRIPTION
Removes a few unnecessary conversions reported by `unconvert`:

```
% golangci-lint run -E unconvert ./...
io/gff/gff.go:253:26: unnecessary conversion (unconvert)
		featureStrand := string(feature.Strand)
		                       ^
io/genbank/genbank.go:748:30: unnecessary conversion (unconvert)
	baseSequenceLength := string(basePairRegex.FindString(locusString))
	                            ^
synthesis/codon/codon.go:426:27: unnecessary conversion (unconvert)
	_ = json.Unmarshal([]byte(file), &codonTable)
```