### PR TITLE
transform: performance like it matters

### DIFF
--- a/transform/examples_test.go
+++ b/transform/examples_test.go
@@ -2,7 +2,6 @@ package transform_test
 
 import (
 	"fmt"
-	"testing"
 
 	"github.com/TimothyStiles/poly/transform"
 )
@@ -29,51 +28,4 @@ func ExampleReverse() {
 	fmt.Println(reverse)
 
 	// Output: ACATTAG
-}
-func TestA(t *testing.T) {
-	for k, v := range complementBaseRuneMap2 {
-		got := transform.ComplementBase(k)
-		if v != got {
-			t.Errorf("%q: %q %q", k, v, got)
-		}
-		gotInverse := transform.ComplementBase(got)
-		if gotInverse != k {
-			t.Errorf("%q: %q %q", got, k, gotInverse)
-		}
-	}
-}
-
-var complementBaseRuneMap2 = map[rune]rune{
-	'A': 'T',
-	'B': 'V',
-	'C': 'G',
-	'D': 'H',
-	'G': 'C',
-	'H': 'D',
-	'K': 'M',
-	'M': 'K',
-	'N': 'N',
-	'R': 'Y',
-	'S': 'S',
-	'T': 'A',
-	'U': 'A',
-	'V': 'B',
-	'W': 'W',
-	'Y': 'R',
-	'a': 't',
-	'b': 'v',
-	'c': 'g',
-	'd': 'h',
-	'g': 'a',
-	'h': 'd',
-	'k': 'm',
-	'm': 'k',
-	'n': 'n',
-	'r': 'y',
-	's': 's',
-	't': 'a',
-	'u': 'a',
-	'v': 'b',
-	'w': 'w',
-	'y': 'r',
 }

--- a/transform/examples_test.go
+++ b/transform/examples_test.go
@@ -1,0 +1,79 @@
+package transform_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/TimothyStiles/poly/transform"
+)
+
+func ExampleReverseComplement() {
+	sequence := "GATTACA"
+	reverseComplement := transform.ReverseComplement(sequence)
+	fmt.Println(reverseComplement)
+
+	// Output: TGTAATC
+}
+
+func ExampleComplement() {
+	sequence := "GATTACA"
+	complement := transform.Complement(sequence)
+	fmt.Println(complement)
+
+	// Output: CTAATGT
+}
+
+func ExampleReverse() {
+	sequence := "GATTACA"
+	reverse := transform.Reverse(sequence)
+	fmt.Println(reverse)
+
+	// Output: ACATTAG
+}
+func TestA(t *testing.T) {
+	for k, v := range complementBaseRuneMap2 {
+		got := transform.ComplementBase(k)
+		if v != got {
+			t.Errorf("%q: %q %q", k, v, got)
+		}
+		gotInverse := transform.ComplementBase(got)
+		if gotInverse != k {
+			t.Errorf("%q: %q %q", got, k, gotInverse)
+		}
+	}
+}
+
+var complementBaseRuneMap2 = map[rune]rune{
+	'A': 'T',
+	'B': 'V',
+	'C': 'G',
+	'D': 'H',
+	'G': 'C',
+	'H': 'D',
+	'K': 'M',
+	'M': 'K',
+	'N': 'N',
+	'R': 'Y',
+	'S': 'S',
+	'T': 'A',
+	'U': 'A',
+	'V': 'B',
+	'W': 'W',
+	'Y': 'R',
+	'a': 't',
+	'b': 'v',
+	'c': 'g',
+	'd': 'h',
+	'g': 'a',
+	'h': 'd',
+	'k': 'm',
+	'm': 'k',
+	'n': 'n',
+	'r': 'y',
+	's': 's',
+	't': 'a',
+	'u': 'a',
+	'v': 'b',
+	'w': 'w',
+	'y': 'r',
+}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -36,7 +36,7 @@ var complementBaseRuneMap = map[rune]rune{
 	98:  118, // b -> v
 	99:  103, // c -> g
 	100: 104, // d -> h
-	103: 99,  // g -> a
+	103: 99,  // g -> a mistake?
 	104: 100, // h -> d
 	107: 109, // k -> m
 	109: 107, // m -> k
@@ -48,6 +48,43 @@ var complementBaseRuneMap = map[rune]rune{
 	118: 98,  // v -> b
 	119: 119, // w -> w
 	121: 114, // y -> r
+}
+
+const aa = 'a'
+
+var complementBaseRuneMap2 = map[rune]rune{
+	'A': 'T',
+	'B': 'V',
+	'C': 'G',
+	'D': 'H',
+	'G': 'C',
+	'H': 'D',
+	'K': 'M',
+	'M': 'K',
+	'N': 'N',
+	'R': 'Y',
+	'S': 'S',
+	'T': 'A',
+	'U': 'A',
+	'V': 'B',
+	'W': 'W',
+	'Y': 'R',
+	'a': 't',
+	'b': 'v',
+	'c': 'g',
+	'd': 'h',
+	'g': 'a',
+	'h': 'd',
+	'k': 'm',
+	'm': 'k',
+	'n': 'n',
+	'r': 'y',
+	's': 's',
+	't': 'a',
+	'u': 'a',
+	'v': 'b',
+	'w': 'w',
+	'y': 'r',
 }
 
 // ReverseComplement takes the reverse complement of a sequence.

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -1,21 +1,17 @@
 /*
 Package transform provides functions for transforming sequences.
-
-Complement takes the complement of a sequence.
-(returns a sequence string where each nucleotide has been swapped with its complement A<->T, C<->G)
-
-Reverse takes the reverse of a sequence.
-(literally just reverses a string. Exists in stdlib but hey why not have it here too?)
-
-ReverseComplement takes the reverse complement of a sequence.
-(Reverses the sequence string and returns the complement of the reversed sequence.)
 */
 package transform
 
 import "unsafe"
 
-// ReverseComplement takes the reverse complement of a sequence.
-// ReverseComplement expects ASCII input.
+// ReverseComplement returns the reversed complement of sequence.
+// It is the equivalent of calling
+//
+//	revComplement := Reverse(Complement(sequence))
+//
+// This function expects byte characters in the range a-z and A-Z and
+// will not check for non-byte characters, i.e. utf-8 encoding.
 func ReverseComplement(sequence string) string {
 	n := len(sequence)
 	newSeq := make([]byte, n)
@@ -26,7 +22,20 @@ func ReverseComplement(sequence string) string {
 	return *(*string)(unsafe.Pointer(&newSeq))
 }
 
-// Complement takes the complement of a sequence.
+// Complement returns the complement of sequence. In [DNA] each nucleotide
+// (A, T, C or G) is has a deterministic pair. A is paired with T and
+// C is paired with G. The complement of a sequence is formed by exchanging
+// these letters for their pair:
+//
+//	'A' becomes 'T'
+//	'T' becomes 'A'
+//	'C' becomes 'G'
+//	'G' becomes 'C'
+//
+// This function expects byte characters in the range a-z and A-Z and
+// will not check for non-byte characters, i.e. utf-8 encoding.
+//
+// [DNA]: https://en.wikipedia.org/wiki/DNA
 func Complement(sequence string) string {
 	n := len(sequence)
 	newSeq := make([]byte, n)
@@ -37,7 +46,11 @@ func Complement(sequence string) string {
 	return *(*string)(unsafe.Pointer(&newSeq))
 }
 
-// Reverse takes the reverse of a sequence.
+// Reverse returns the reverse of sequence. It performs a basic
+// string reversal by working on the bytes.
+//
+// This function expects byte characters in the range a-z and A-Z and
+// will not check for non-byte character, i.e. utf-8 encoding.
 func Reverse(sequence string) string {
 	n := len(sequence)
 	newSeq := make([]byte, n)
@@ -48,7 +61,11 @@ func Reverse(sequence string) string {
 	return *(*string)(unsafe.Pointer(&newSeq))
 }
 
-// ComplementBase accepts a base pair and returns its complement base pair
+// ComplementBase accepts a base pair and returns its complement base pair. See Complement.
+//
+// This function expects byte characters in the range a-z and A-Z and
+// will return a space ' ' (U+0020) for characters that are not matched
+// to any known base. This is subject to change.
 func ComplementBase(basePair rune) rune {
 	got := rune(complementTable[basePair])
 	if got == 0 {

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -13,10 +13,10 @@ import "unsafe"
 // This function expects byte characters in the range a-z and A-Z and
 // will not check for non-byte characters, i.e. utf-8 encoding.
 func ReverseComplement(sequence string) string {
-	n := len(sequence)
-	newSeq := make([]byte, n)
-	for i := 0; i < n; i++ {
-		newSeq[i] = complementTable[sequence[n-i-1]]
+	seqLen := len(sequence)
+	newSeq := make([]byte, seqLen)
+	for idx := 0; idx < seqLen; idx++ {
+		newSeq[idx] = complementTable[sequence[seqLen-idx-1]]
 	}
 	// This is how strings.Builder works with the String() method. If Mr. Go says it's safe...
 	return *(*string)(unsafe.Pointer(&newSeq))
@@ -37,10 +37,10 @@ func ReverseComplement(sequence string) string {
 //
 // [DNA]: https://en.wikipedia.org/wiki/DNA
 func Complement(sequence string) string {
-	n := len(sequence)
-	newSeq := make([]byte, n)
-	for i := 0; i < n; i++ {
-		newSeq[i] = complementTable[sequence[i]]
+	seqLen := len(sequence)
+	newSeq := make([]byte, seqLen)
+	for idx := 0; idx < seqLen; idx++ {
+		newSeq[idx] = complementTable[sequence[idx]]
 	}
 	// This is how strings.Builder works with the String() method. If Mr. Go says it's safe...
 	return *(*string)(unsafe.Pointer(&newSeq))
@@ -52,10 +52,10 @@ func Complement(sequence string) string {
 // This function expects byte characters in the range a-z and A-Z and
 // will not check for non-byte character, i.e. utf-8 encoding.
 func Reverse(sequence string) string {
-	n := len(sequence)
-	newSeq := make([]byte, n)
-	for i := 0; i < n; i++ {
-		newSeq[i] = sequence[n-i-1]
+	seqLen := len(sequence)
+	newSeq := make([]byte, seqLen)
+	for idx := 0; idx < seqLen; idx++ {
+		newSeq[idx] = sequence[seqLen-idx-1]
 	}
 	// This is how strings.Builder works with the String() method. If Mr. Go says it's safe...
 	return *(*string)(unsafe.Pointer(&newSeq))

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -12,7 +12,10 @@ ReverseComplement takes the reverse complement of a sequence.
 */
 package transform
 
-import "strings"
+import (
+	"strings"
+	"unsafe"
+)
 
 // complementBaseRuneMap provides 1:1 mapping between bases and their complements
 var complementBaseRuneMap = map[rune]rune{
@@ -50,9 +53,7 @@ var complementBaseRuneMap = map[rune]rune{
 	121: 114, // y -> r
 }
 
-const aa = 'a'
-
-var complementBaseRuneMap2 = map[rune]rune{
+var complementTable = [256]byte{
 	'A': 'T',
 	'B': 'V',
 	'C': 'G',
@@ -88,15 +89,15 @@ var complementBaseRuneMap2 = map[rune]rune{
 }
 
 // ReverseComplement takes the reverse complement of a sequence.
+// ReverseComplement expects ASCII input.
 func ReverseComplement(sequence string) string {
-	complementString := strings.Map(ComplementBase, sequence)
-	length := len(complementString)
-	newString := make([]rune, length)
-	for _, base := range complementString {
-		length--
-		newString[length] = base
+	n := len(sequence)
+	newSeq := make([]byte, n)
+	for i := 0; i < n; i++ {
+		newSeq[i] = complementTable[sequence[n-i-1]]
 	}
-	return string(newString)
+	// This is how strings.Builder works with the String() method. If Mr. Go says it's safe...
+	return *(*string)(unsafe.Pointer(&newSeq))
 }
 
 // Complement takes the complement of a sequence.

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -12,47 +12,52 @@ ReverseComplement takes the reverse complement of a sequence.
 */
 package transform
 
-import (
-	"strings"
-	"unsafe"
-)
+import "unsafe"
 
-// complementBaseRuneMap provides 1:1 mapping between bases and their complements
-var complementBaseRuneMap = map[rune]rune{
-	65:  84,  // A -> T
-	66:  86,  // B -> V
-	67:  71,  // C -> G
-	68:  72,  // D -> H
-	71:  67,  // G -> C
-	72:  68,  // H -> D
-	75:  77,  // K -> M
-	77:  75,  // M -> K
-	78:  78,  // N -> N
-	82:  89,  // R -> Y
-	83:  83,  // S -> S
-	84:  65,  // T -> A
-	85:  65,  // U -> A
-	86:  66,  // V -> B
-	87:  87,  // W -> W
-	89:  82,  // Y -> R
-	97:  116, // a -> t
-	98:  118, // b -> v
-	99:  103, // c -> g
-	100: 104, // d -> h
-	103: 99,  // g -> a mistake?
-	104: 100, // h -> d
-	107: 109, // k -> m
-	109: 107, // m -> k
-	110: 110, // n -> n
-	114: 121, // r -> y
-	115: 115, // s -> s
-	116: 97,  // t -> a
-	117: 97,  // u -> a
-	118: 98,  // v -> b
-	119: 119, // w -> w
-	121: 114, // y -> r
+// ReverseComplement takes the reverse complement of a sequence.
+// ReverseComplement expects ASCII input.
+func ReverseComplement(sequence string) string {
+	n := len(sequence)
+	newSeq := make([]byte, n)
+	for i := 0; i < n; i++ {
+		newSeq[i] = complementTable[sequence[n-i-1]]
+	}
+	// This is how strings.Builder works with the String() method. If Mr. Go says it's safe...
+	return *(*string)(unsafe.Pointer(&newSeq))
 }
 
+// Complement takes the complement of a sequence.
+func Complement(sequence string) string {
+	n := len(sequence)
+	newSeq := make([]byte, n)
+	for i := 0; i < n; i++ {
+		newSeq[i] = complementTable[sequence[i]]
+	}
+	// This is how strings.Builder works with the String() method. If Mr. Go says it's safe...
+	return *(*string)(unsafe.Pointer(&newSeq))
+}
+
+// Reverse takes the reverse of a sequence.
+func Reverse(sequence string) string {
+	n := len(sequence)
+	newSeq := make([]byte, n)
+	for i := 0; i < n; i++ {
+		newSeq[i] = sequence[n-i-1]
+	}
+	// This is how strings.Builder works with the String() method. If Mr. Go says it's safe...
+	return *(*string)(unsafe.Pointer(&newSeq))
+}
+
+// ComplementBase accepts a base pair and returns its complement base pair
+func ComplementBase(basePair rune) rune {
+	got := rune(complementTable[basePair])
+	if got == 0 {
+		return ' ' // invalid sequence returns empty space.
+	}
+	return got
+}
+
+// complementTable provides 1:1 mapping between bases and their complements
 var complementTable = [256]byte{
 	'A': 'T',
 	'B': 'V',
@@ -74,7 +79,7 @@ var complementTable = [256]byte{
 	'b': 'v',
 	'c': 'g',
 	'd': 'h',
-	'g': 'a',
+	'g': 'c',
 	'h': 'd',
 	'k': 'm',
 	'm': 'k',
@@ -86,38 +91,4 @@ var complementTable = [256]byte{
 	'v': 'b',
 	'w': 'w',
 	'y': 'r',
-}
-
-// ReverseComplement takes the reverse complement of a sequence.
-// ReverseComplement expects ASCII input.
-func ReverseComplement(sequence string) string {
-	n := len(sequence)
-	newSeq := make([]byte, n)
-	for i := 0; i < n; i++ {
-		newSeq[i] = complementTable[sequence[n-i-1]]
-	}
-	// This is how strings.Builder works with the String() method. If Mr. Go says it's safe...
-	return *(*string)(unsafe.Pointer(&newSeq))
-}
-
-// Complement takes the complement of a sequence.
-func Complement(sequence string) string {
-	complementString := strings.Map(ComplementBase, sequence)
-	return complementString
-}
-
-// Reverse takes the reverse of a sequence.
-func Reverse(sequence string) string {
-	length := len(sequence)
-	newString := make([]rune, length)
-	for _, base := range sequence {
-		length--
-		newString[length] = base
-	}
-	return string(newString)
-}
-
-// ComplementBase accepts a base pair and returns its complement base pair
-func ComplementBase(basePair rune) rune {
-	return complementBaseRuneMap[basePair]
 }

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -13,13 +13,13 @@ import "unsafe"
 // This function expects byte characters in the range a-z and A-Z and
 // will not check for non-byte characters, i.e. utf-8 encoding.
 func ReverseComplement(sequence string) string {
-	seqLen := len(sequence)
-	newSeq := make([]byte, seqLen)
-	for idx := 0; idx < seqLen; idx++ {
-		newSeq[idx] = complementTable[sequence[seqLen-idx-1]]
+	sequenceLength := len(sequence)
+	newSequence := make([]byte, sequenceLength)
+	for index := 0; index < sequenceLength; index++ {
+		newSequence[index] = complementTable[sequence[sequenceLength-index-1]]
 	}
 	// This is how strings.Builder works with the String() method. If Mr. Go says it's safe...
-	return *(*string)(unsafe.Pointer(&newSeq))
+	return *(*string)(unsafe.Pointer(&newSequence))
 }
 
 // Complement returns the complement of sequence. In [DNA] each nucleotide
@@ -37,13 +37,13 @@ func ReverseComplement(sequence string) string {
 //
 // [DNA]: https://en.wikipedia.org/wiki/DNA
 func Complement(sequence string) string {
-	seqLen := len(sequence)
-	newSeq := make([]byte, seqLen)
-	for idx := 0; idx < seqLen; idx++ {
-		newSeq[idx] = complementTable[sequence[idx]]
+	sequenceLength := len(sequence)
+	newSequence := make([]byte, sequenceLength)
+	for index := 0; index < sequenceLength; index++ {
+		newSequence[index] = complementTable[sequence[index]]
 	}
 	// This is how strings.Builder works with the String() method. If Mr. Go says it's safe...
-	return *(*string)(unsafe.Pointer(&newSeq))
+	return *(*string)(unsafe.Pointer(&newSequence))
 }
 
 // Reverse returns the reverse of sequence. It performs a basic
@@ -52,13 +52,13 @@ func Complement(sequence string) string {
 // This function expects byte characters in the range a-z and A-Z and
 // will not check for non-byte character, i.e. utf-8 encoding.
 func Reverse(sequence string) string {
-	seqLen := len(sequence)
-	newSeq := make([]byte, seqLen)
-	for idx := 0; idx < seqLen; idx++ {
-		newSeq[idx] = sequence[seqLen-idx-1]
+	sequenceLength := len(sequence)
+	newSequence := make([]byte, sequenceLength)
+	for index := 0; index < sequenceLength; index++ {
+		newSequence[index] = sequence[sequenceLength-index-1]
 	}
 	// This is how strings.Builder works with the String() method. If Mr. Go says it's safe...
-	return *(*string)(unsafe.Pointer(&newSeq))
+	return *(*string)(unsafe.Pointer(&newSequence))
 }
 
 // ComplementBase accepts a base pair and returns its complement base pair. See Complement.

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -60,6 +60,21 @@ func TestReverseComplement(t *testing.T) {
 	}
 }
 
+func TestComplementBase(t *testing.T) {
+	var letters = [...]byte{'A', 'B', 'C', 'D', 'G', 'H', 'K', 'M', 'N', 'R', 'S', 'T', 'U', 'V', 'W', 'Y', 'a', 'b', 'c', 'd', 'g', 'h', 'k', 'm', 'n', 'r', 's', 't', 'u', 'v', 'w', 'y'}
+	for _, c := range letters {
+		got := ComplementBase(rune(c))
+		gotI := ComplementBase(got)
+		gotII := ComplementBase(gotI)
+		if (c == 'U' && got == 'A') || (c == 'u' && got == 'a') {
+			continue // Edge case: RNA Uracil base-pairs with Adenine.
+		}
+		if rune(c) != gotI || gotII != got {
+			t.Errorf("complement transform mismatch: %q->%q->%q->%q", c, got, gotI, gotII)
+		}
+	}
+}
+
 func TestComplementBaseError(t *testing.T) {
 	complementBase := ComplementBase('!')
 	if complementBase != ' ' {

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -3,6 +3,7 @@ package transform
 import (
 	"math/rand"
 	"testing"
+	"unsafe"
 )
 
 // goos: linux
@@ -41,3 +42,14 @@ func randomSequence(rnd *rand.Rand) string {
 }
 
 var letters = [...]byte{'A', 'B', 'C', 'D', 'G', 'H', 'K', 'M', 'N', 'R', 'S', 'T', 'U', 'V', 'W', 'Y', 'a', 'b', 'c', 'd', 'g', 'h', 'k', 'm', 'n', 'r', 's', 't', 'u', 'v', 'w', 'y'}
+
+// ReverseComplement takes the reverse complement of a sequence.
+func ReverseComplement2(sequence string) string {
+	n := len(sequence)
+	newSeq := make([]byte, n)
+	for i := 0; i < n; i++ {
+		newSeq[i] = complementTable[sequence[n-i-1]]
+	}
+	// This is how strings.Builder works with the String() method.
+	return *(*string)(unsafe.Pointer(&newSeq))
+}

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -3,97 +3,86 @@ package transform
 import (
 	"math/rand"
 	"testing"
+
+	"github.com/TimothyStiles/poly/random"
 )
 
 func TestReverse(t *testing.T) {
-	rng := rand.New(rand.NewSource(1))
-	sequence := randomSequence(rng)
+	seed := rand.New(rand.NewSource(1)).Int63()
+	sequence, err := random.DNASequence(20, seed)
+	if err != nil {
+		t.Errorf("failed to generate random DNA sequence")
+	}
 	// Test even and odd lengthed string.
-	for _, test := range []string{sequence, sequence[:len(sequence)-1]} {
-		got := Reverse(test)
-		for idx := range got[:len(got)/2+1] {
-			gotbase := got[idx]
-			expect := test[len(test)-idx-1]
+	evenAndOddLengthSequences := []string{sequence, sequence[:len(sequence)-1]} // indexing just removes last character of sequence for even/odd check
+	for _, testSequence := range evenAndOddLengthSequences {
+		reversedSequence := Reverse(testSequence)
+		for index := range reversedSequence[:len(reversedSequence)/2+1] {
+			gotbase := reversedSequence[index]
+			expect := testSequence[len(testSequence)-index-1]
 			if gotbase != expect {
-				t.Errorf("mismatch at pos %d, got %q, expect %q", idx, gotbase, expect)
+				t.Errorf("mismatch at pos %d, got %q, expect %q", index, gotbase, expect)
 			}
 		}
 	}
 }
 
 func TestComplement(t *testing.T) {
-	rng := rand.New(rand.NewSource(1))
-	original := randomSequence(rng)
-	for _, test := range []string{original} {
-		gotSequence := Complement(test)
-		for idx, got := range gotSequence {
-			expect := ComplementBase(rune(test[idx]))
-			if got != expect {
-				t.Errorf("bad %q complement: got %q, expect %q", test[idx], got, expect)
+	seed := rand.New(rand.NewSource(1)).Int63()
+	sequence, err := random.DNASequence(20, seed)
+	if err != nil {
+		t.Errorf("failed to generate random DNA sequence")
+	}
+	for _, testSequence := range []string{sequence} { // loop is unneeded but makes it easier to add more test cases in the future.
+		complementSequence := Complement(testSequence)
+		for index, complement := range complementSequence {
+			expectedBase := ComplementBase(rune(testSequence[index]))
+			if complement != expectedBase {
+				t.Errorf("bad %q complement: got %q, expect %q", testSequence[index], complement, expectedBase)
 			}
 		}
 	}
 }
 
 func TestReverseComplement(t *testing.T) {
-	rng := rand.New(rand.NewSource(1))
-	original := randomSequence(rng)
-	for _, test := range []string{original, original[:len(original)-1]} {
-		got := ReverseComplement(test)
-		expect := Reverse(Complement(test))
+	seed := rand.New(rand.NewSource(1)).Int63()
+	sequence, err := random.DNASequence(20, seed)
+	if err != nil {
+		t.Errorf("failed to generate random DNA sequence")
+	}
+	evenAndOddLengthSequences := []string{sequence, sequence[:len(sequence)-1]}
+	for _, testSequence := range evenAndOddLengthSequences {
+		got := ReverseComplement(testSequence)
+		expect := Reverse(Complement(testSequence))
 		if got != expect {
 			t.Errorf("mismatch with individual Reverse and Complement call:\n%q\n%q", got, expect)
 		}
 	}
 }
 
-func TestComplementBase(t *testing.T) {
-	for _, c := range letters {
-		got := ComplementBase(rune(c))
-		gotI := ComplementBase(got)
-		gotII := ComplementBase(gotI)
-		if (c == 'U' && got == 'A') || (c == 'u' && got == 'a') {
-			continue // Edge case: RNA Uracil base-pairs with Adenine.
-		}
-		if rune(c) != gotI || gotII != got {
-			t.Errorf("complement transform mismatch: %q->%q->%q->%q", c, got, gotI, gotII)
-		}
-	}
-}
-
-func randomSequence(rnd *rand.Rand) string {
-	// TODO(soypat): make a more professional random sequencer
-	// Probably could have a length argument.
-	lettersCopy := letters
-	rnd.Shuffle(len(lettersCopy), func(i, j int) { lettersCopy[i], lettersCopy[j] = lettersCopy[j], lettersCopy[i] })
-	return string(lettersCopy[:])
-}
-
-var letters = [...]byte{'A', 'B', 'C', 'D', 'G', 'H', 'K', 'M', 'N', 'R', 'S', 'T', 'U', 'V', 'W', 'Y', 'a', 'b', 'c', 'd', 'g', 'h', 'k', 'm', 'n', 'r', 's', 't', 'u', 'v', 'w', 'y'}
-
 func BenchmarkReverseComplement(b *testing.B) {
-	rng := rand.New(rand.NewSource(1))
-	seq := randomSequence(rng)
-	for idx := 0; idx < b.N; idx++ {
-		seq = ReverseComplement(seq)
+	seed := rand.New(rand.NewSource(1)).Int63()
+	sequence, _ := random.DNASequence(8, seed)
+	for index := 0; index < b.N; index++ {
+		sequence = ReverseComplement(sequence)
 	}
-	_ = seq
+	_ = sequence
 }
 
 func BenchmarkComplement(b *testing.B) {
-	rng := rand.New(rand.NewSource(1))
-	seq := randomSequence(rng)
-	for idx := 0; idx < b.N; idx++ {
-		seq = Complement(seq)
+	seed := rand.New(rand.NewSource(1)).Int63()
+	sequence, _ := random.DNASequence(8, seed)
+	for index := 0; index < b.N; index++ {
+		sequence = Complement(sequence)
 	}
-	_ = seq
+	_ = sequence
 }
 
 func BenchmarkReverse(b *testing.B) {
-	rng := rand.New(rand.NewSource(1))
-	seq := randomSequence(rng)
-	for idx := 0; idx < b.N; idx++ {
-		seq = Reverse(seq)
+	seed := rand.New(rand.NewSource(1)).Int63()
+	sequence, _ := random.DNASequence(8, seed)
+	for index := 0; index < b.N; index++ {
+		sequence = Reverse(sequence)
 	}
-	_ = seq
+	_ = sequence
 }

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -62,9 +62,11 @@ func TestComplementBase(t *testing.T) {
 }
 
 func randomSequence(rnd *rand.Rand) string {
-	cp := letters
-	rnd.Shuffle(len(cp), func(i, j int) { cp[i], cp[j] = cp[j], cp[i] })
-	return string(cp[:])
+	// TODO(soypat): make a more professional random sequencer
+	// Probably could have a length argument.
+	lettersCopy := letters
+	rnd.Shuffle(len(lettersCopy), func(i, j int) { lettersCopy[i], lettersCopy[j] = lettersCopy[j], lettersCopy[i] })
+	return string(lettersCopy[:])
 }
 
 var letters = [...]byte{'A', 'B', 'C', 'D', 'G', 'H', 'K', 'M', 'N', 'R', 'S', 'T', 'U', 'V', 'W', 'Y', 'a', 'b', 'c', 'd', 'g', 'h', 'k', 'm', 'n', 'r', 's', 't', 'u', 'v', 'w', 'y'}

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -1,31 +1,43 @@
-package transform_test
+package transform
 
 import (
-	"fmt"
-
-	"github.com/TimothyStiles/poly/transform"
+	"math/rand"
+	"testing"
 )
 
-func ExampleReverseComplement() {
-	sequence := "GATTACA"
-	reverseComplement := transform.ReverseComplement(sequence)
-	fmt.Println(reverseComplement)
-
-	// Output: TGTAATC
+// goos: linux
+// goarch: amd64
+// pkg: github.com/TimothyStiles/poly/transform
+// cpu: Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz
+// BenchmarkReverseComplement-8   	 1804766	       669.8 ns/op	     224 B/op	       3 allocs/op
+// PASS
+func BenchmarkReverseComplement(b *testing.B) {
+	rng := rand.New(rand.NewSource(1))
+	seq := randomSequence(rng)
+	for i := 0; i < b.N; i++ {
+		seq = ReverseComplement(seq)
+	}
+	_ = seq
 }
 
-func ExampleComplement() {
-	sequence := "GATTACA"
-	complement := transform.Complement(sequence)
-	fmt.Println(complement)
-
-	// Output: CTAATGT
+func TestComplementBase(t *testing.T) {
+	for _, c := range letters {
+		got := ComplementBase(rune(c))
+		gotI := ComplementBase(got)
+		gotII := ComplementBase(gotI)
+		if rune(c) != gotI {
+			t.Errorf("double complement should yield start: %q->%q->%q", c, got, gotI)
+		}
+		if gotII != got {
+			t.Errorf("double complement should yield start: %q->%q->%q", got, gotI, gotII)
+		}
+	}
 }
 
-func ExampleReverse() {
-	sequence := "GATTACA"
-	reverse := transform.Reverse(sequence)
-	fmt.Println(reverse)
-
-	// Output: ACATTAG
+func randomSequence(rnd *rand.Rand) string {
+	cp := letters
+	rnd.Shuffle(len(cp), func(i, j int) { cp[i], cp[j] = cp[j], cp[i] })
+	return string(cp[:])
 }
+
+var letters = [...]byte{'A', 'B', 'C', 'D', 'G', 'H', 'K', 'M', 'N', 'R', 'S', 'T', 'U', 'V', 'W', 'Y', 'a', 'b', 'c', 'd', 'g', 'h', 'k', 'm', 'n', 'r', 's', 't', 'u', 'v', 'w', 'y'}

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -60,6 +60,13 @@ func TestReverseComplement(t *testing.T) {
 	}
 }
 
+func TestComplementBaseError(t *testing.T) {
+	complementBase := ComplementBase('!')
+	if complementBase != ' ' {
+		t.Errorf("expected space for invalid base")
+	}
+}
+
 func BenchmarkReverseComplement(b *testing.B) {
 	seed := rand.New(rand.NewSource(1)).Int63()
 	sequence, _ := random.DNASequence(8, seed)

--- a/transform/transform_test.go
+++ b/transform/transform_test.go
@@ -11,11 +11,11 @@ func TestReverse(t *testing.T) {
 	// Test even and odd lengthed string.
 	for _, test := range []string{sequence, sequence[:len(sequence)-1]} {
 		got := Reverse(test)
-		for i := range got[:len(got)/2+1] {
-			gotbase := got[i]
-			expect := test[len(test)-i-1]
+		for idx := range got[:len(got)/2+1] {
+			gotbase := got[idx]
+			expect := test[len(test)-idx-1]
 			if gotbase != expect {
-				t.Errorf("mismatch at pos %d, got %q, expect %q", i, gotbase, expect)
+				t.Errorf("mismatch at pos %d, got %q, expect %q", idx, gotbase, expect)
 			}
 		}
 	}
@@ -26,10 +26,10 @@ func TestComplement(t *testing.T) {
 	original := randomSequence(rng)
 	for _, test := range []string{original} {
 		gotSequence := Complement(test)
-		for i, got := range gotSequence {
-			expect := ComplementBase(rune(test[i]))
+		for idx, got := range gotSequence {
+			expect := ComplementBase(rune(test[idx]))
 			if got != expect {
-				t.Errorf("bad %q complement: got %q, expect %q", test[i], got, expect)
+				t.Errorf("bad %q complement: got %q, expect %q", test[idx], got, expect)
 			}
 		}
 	}
@@ -74,7 +74,7 @@ var letters = [...]byte{'A', 'B', 'C', 'D', 'G', 'H', 'K', 'M', 'N', 'R', 'S', '
 func BenchmarkReverseComplement(b *testing.B) {
 	rng := rand.New(rand.NewSource(1))
 	seq := randomSequence(rng)
-	for i := 0; i < b.N; i++ {
+	for idx := 0; idx < b.N; idx++ {
 		seq = ReverseComplement(seq)
 	}
 	_ = seq
@@ -83,7 +83,7 @@ func BenchmarkReverseComplement(b *testing.B) {
 func BenchmarkComplement(b *testing.B) {
 	rng := rand.New(rand.NewSource(1))
 	seq := randomSequence(rng)
-	for i := 0; i < b.N; i++ {
+	for idx := 0; idx < b.N; idx++ {
 		seq = Complement(seq)
 	}
 	_ = seq
@@ -92,7 +92,7 @@ func BenchmarkComplement(b *testing.B) {
 func BenchmarkReverse(b *testing.B) {
 	rng := rand.New(rand.NewSource(1))
 	seq := randomSequence(rng)
-	for i := 0; i < b.N; i++ {
+	for idx := 0; idx < b.N; idx++ {
 		seq = Reverse(seq)
 	}
 	_ = seq


### PR DESCRIPTION
Lot of noise in this PR, sorry about that. What matters is that
* I'm using a 256byte table for complement calculation instead of map
* I'm avoiding heap allocations where possible by using a byte slice and unsafe conversion.

```go
// ReverseComplement takes the reverse complement of a sequence.
// ReverseComplement expects ASCII input.
func ReverseComplement(sequence string) string {
    n := len(sequence)
    newSeq := make([]byte, n)
    for i := 0; i < n; i++ {
        newSeq[i] = complementTable[sequence[n-i-1]]
    }
    // This is how strings.Builder works with the String() method. If Mr. Go says it's safe...
    return *(*string)(unsafe.Pointer(&newSeq))
}
```