### PR TITLE
Fixed the issue `rebase can contain multiple references`

### DIFF
--- a/io/fasta/fasta.go
+++ b/io/fasta/fasta.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -193,5 +192,5 @@ func Write(fastas []Fasta, path string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, fastaBytes, 0644)
+	return os.WriteFile(path, fastaBytes, 0644)
 }

--- a/io/genbank/example_test.go
+++ b/io/genbank/example_test.go
@@ -3,7 +3,6 @@ package genbank_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -29,7 +28,7 @@ func ExampleRead() {
 }
 
 func ExampleWrite() {
-	tmpDataDir, err := ioutil.TempDir("", "data-*")
+	tmpDataDir, err := os.MkdirTemp("", "data-*")
 	if err != nil {
 		fmt.Println(err.Error())
 	}
@@ -74,7 +73,7 @@ func ExampleReadMulti() {
 }
 
 func ExampleWriteMulti() {
-	tmpDataDir, err := ioutil.TempDir("", "data-*")
+	tmpDataDir, err := os.MkdirTemp("", "data-*")
 	if err != nil {
 		fmt.Println(err.Error())
 	}

--- a/io/genbank/genbank.go
+++ b/io/genbank/genbank.go
@@ -15,7 +15,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -33,7 +32,7 @@ GBK specific IO related things begin here.
 ******************************************************************************/
 
 var (
-	readFileFn        = ioutil.ReadFile
+	readFileFn        = os.ReadFile
 	parseMultiNthFn   = ParseMultiNth
 	parseReferencesFn = parseReferences
 )
@@ -187,7 +186,7 @@ func Write(sequences Genbank, path string) error {
 	// add error handling in the future.
 	gbk, _ := Build(sequences)
 
-	err := ioutil.WriteFile(path, gbk, 0644)
+	err := os.WriteFile(path, gbk, 0644)
 	return err
 }
 
@@ -198,7 +197,7 @@ func WriteMulti(sequences []Genbank, path string) error {
 	// add error handling in the future.
 	gbk, _ := BuildMulti(sequences)
 
-	err := ioutil.WriteFile(path, gbk, 0644)
+	err := os.WriteFile(path, gbk, 0644)
 	return err
 }
 

--- a/io/genbank/genbank_test.go
+++ b/io/genbank/genbank_test.go
@@ -3,7 +3,6 @@ package genbank
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,7 +33,7 @@ var singleGbkPaths = []string{
 }
 
 func TestGbkIO(t *testing.T) {
-	tmpDataDir, err := ioutil.TempDir("", "data-*")
+	tmpDataDir, err := os.MkdirTemp("", "data-*")
 	if err != nil {
 		t.Error(err)
 	}
@@ -68,7 +67,7 @@ func TestMultiLineFeatureParse(t *testing.T) {
 }
 
 func TestMultiGenbankIO(t *testing.T) {
-	tmpDataDir, err := ioutil.TempDir("", "data-*")
+	tmpDataDir, err := os.MkdirTemp("", "data-*")
 	if err != nil {
 		t.Error(err)
 	}
@@ -89,7 +88,7 @@ func TestMultiGenbankIO(t *testing.T) {
 }
 
 func TestGbkLocationStringBuilder(t *testing.T) {
-	tmpDataDir, err := ioutil.TempDir("", "data-*")
+	tmpDataDir, err := os.MkdirTemp("", "data-*")
 	if err != nil {
 		t.Error(err)
 	}
@@ -117,7 +116,7 @@ func TestGbkLocationStringBuilder(t *testing.T) {
 }
 
 func TestGbLocationStringBuilder(t *testing.T) {
-	tmpDataDir, err := ioutil.TempDir("", "data-*")
+	tmpDataDir, err := os.MkdirTemp("", "data-*")
 	if err != nil {
 		t.Error(err)
 	}

--- a/io/gff/example_test.go
+++ b/io/gff/example_test.go
@@ -3,7 +3,6 @@ package gff_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -49,7 +48,7 @@ func ExampleBuild() {
 }
 
 func ExampleWrite() {
-	tmpDataDir, err := ioutil.TempDir("", "data-*")
+	tmpDataDir, err := os.MkdirTemp("", "data-*")
 	if err != nil {
 		fmt.Println(err.Error())
 	}

--- a/io/gff/gff_test.go
+++ b/io/gff/gff_test.go
@@ -24,7 +24,7 @@ Gff related tests and benchmarks begin here.
 // TODO should delete output files.
 
 func TestGffIO(t *testing.T) {
-	tmpDataDir, err := ioutil.TempDir("", "data-*")
+	tmpDataDir, err := os.MkdirTemp("", "data-*")
 	if err != nil {
 		t.Error(err)
 	}

--- a/io/polyjson/example_test.go
+++ b/io/polyjson/example_test.go
@@ -2,7 +2,6 @@ package polyjson_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -14,7 +13,7 @@ import (
 func Example() {
 
 	// this example also is run by the poly's test suite so this just sets up a temporary directory for writing files
-	tmpDataDir, err := ioutil.TempDir("", "data-*")
+	tmpDataDir, err := os.MkdirTemp("", "data-*")
 	if err != nil {
 		fmt.Println(err.Error())
 	}
@@ -74,7 +73,7 @@ func ExampleParse() {
 }
 
 func ExampleWrite() {
-	tmpDataDir, err := ioutil.TempDir("", "data-*")
+	tmpDataDir, err := os.MkdirTemp("", "data-*")
 	if err != nil {
 		fmt.Println(err.Error())
 	}

--- a/io/rebase/data/rebase_minimal.json
+++ b/io/rebase/data/rebase_minimal.json
@@ -1,0 +1,91 @@
+{
+    "AaaI": {
+        "name": "AaaI",
+        "isoschizomers": [
+            "XmaIII",
+            "BseX3I",
+            "BsoDI",
+            "BstZI",
+            "EagI",
+            "EclXI",
+            "Eco52I",
+            "SenPT16I",
+            "TauII",
+            "Tsp504I"
+        ],
+        "recognitionSequence": "C^GGCCG",
+        "methylationSite": "",
+        "microorganism": "Acetobacter aceti ss aceti",
+        "source": "M. Fukaya",
+        "commercialAvailability": null,
+        "references": [
+            "Tagami, H., Tayama, K., Tohyama, T., Fukaya, M., Okumura, H., Kawamura, Y., Horinouchi, S., Beppu, T., (1988) FEMS Microbiol. Lett., vol. 56, pp. 161-166."
+        ]
+    },
+    "AarI": {
+        "name": "AarI",
+        "isoschizomers": [
+            "PaqCI"
+        ],
+        "recognitionSequence": "CACCTGC(4/8)",
+        "methylationSite": "",
+        "microorganism": "Arthrobacter aurescens SS2-322",
+        "source": "A. Janulaitis",
+        "commercialAvailability": [
+            {
+                "organization": "Life Technologies",
+                "lastUpdated": "2021-01-03T01:00:00Z"
+            }
+        ],
+        "references": [
+            "Grigaite, R., Maneliene, Z., Janulaitis, A., (2002) Nucleic Acids Res., vol. 30.",
+            "Maneliene, Z., Zakareviciene, L., Unpublished observations."
+        ]
+    },
+    "AatII": {
+        "name": "AatII",
+        "isoschizomers": [
+            "AspJI",
+            "Ppu1253I",
+            "Ssp5230I",
+            "ZraI"
+        ],
+        "recognitionSequence": "GACGT^C",
+        "methylationSite": "2(6)",
+        "microorganism": "Acetobacter aceti IFO 3281",
+        "source": "IFO 3281",
+        "commercialAvailability": [
+            {
+                "organization": "Life Technologies",
+                "lastUpdated": "2021-01-03T01:00:00Z"
+            },
+            {
+                "organization": "SibEnzyme Ltd.",
+                "lastUpdated": "2021-01-03T01:00:00Z"
+            },
+            {
+                "organization": "Takara Bio Inc.",
+                "lastUpdated": "2018-01-06T01:00:00Z"
+            },
+            {
+                "organization": "Roche Applied Science",
+                "lastUpdated": "2018-01-04T01:00:00Z"
+            },
+            {
+                "organization": "New England Biolabs",
+                "lastUpdated": "2021-01-03T01:00:00Z"
+            },
+            {
+                "organization": "Vivantis Technologies",
+                "lastUpdated": "2018-01-01T01:00:00Z"
+            }
+        ],
+        "references": [
+            "Clark, T.A., Murray, I.A., Morgan, R.D., Kislyuk, A.O., Spittle, K.E., Boitano, M., Fomenkov, A., Roberts, R.J., Korlach, J., (2012) Nucleic Acids Res., vol. 40.",
+            "Flodman, K., Xu, S.-Y., Unpublished observations.",
+            "Fomenkov, A., Unpublished observations.",
+            "Sugisaki, H., Maekawa, Y., Kanazawa, S., Takanami, M., (1982) Nucleic Acids Res., vol. 10, pp. 5747-5752.",
+            "Xu, S.-Y., Nwankwo, D.O., European Patent Office, 1992."
+        ]
+    }
+}

--- a/io/rebase/data/rebase_minimal.txt
+++ b/io/rebase/data/rebase_minimal.txt
@@ -1,0 +1,141 @@
+ 
+REBASE version 104                                              withrefm.104
+ 
+    =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+    REBASE, The Restriction Enzyme Database   http://rebase.neb.com
+    Copyright (c)  Dr. Richard J. Roberts, 2021.   All rights reserved.
+    =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ 
+Rich Roberts                                                    Mar 31 2021
+ 
+
+<ENZYME NAME>   Restriction enzyme name.
+<ISOSCHIZOMERS> Other enzymes with this specificity.
+<RECOGNITION SEQUENCE> 
+                These are written from 5' to 3', only one strand being given.
+                If the point of cleavage has been determined, the precise site
+                is marked with ^.  For enzymes such as HgaI, MboII etc., which
+                cleave away from their recognition sequence the cleavage sites
+                are indicated in parentheses.  
+
+                For example HgaI GACGC (5/10) indicates cleavage as follows:
+                                5' GACGCNNNNN^      3'
+                                3' CTGCGNNNNNNNNNN^ 5'
+
+                In all cases the recognition sequences are oriented so that
+                the cleavage sites lie on their 3' side.
+
+                REBASE Recognition sequences representations use the standard 
+                abbreviations (Eur. J. Biochem. 150: 1-5, 1985) to represent 
+                ambiguity.
+                                R = G or A
+                                Y = C or T
+                                M = A or C
+                                K = G or T
+                                S = G or C
+                                W = A or T
+                                B = not A (C or G or T)
+                                D = not C (A or G or T)
+                                H = not G (A or C or T)
+                                V = not T (A or C or G)
+                                N = A or C or G or T
+
+
+
+                ENZYMES WITH UNUSUAL CLEAVAGE PROPERTIES:  
+
+                Enzymes that cut on both sides of their recognition sequences,
+                such as BcgI, Bsp24I, CjeI and CjePI, have 4 cleavage sites
+                each instead of 2.
+
+                Bsp24I
+                          5'      ^NNNNNNNNGACNNNNNNTGGNNNNNNNNNNNN^   3'
+                          3' ^NNNNNNNNNNNNNCTGNNNNNNACCNNNNNNN^        5'
+
+
+                This will be described in some REBASE reports as:
+
+                             Bsp24I (8/13)GACNNNNNNTGG(12/7)
+
+<METHYLATION SITE>
+                The site of methylation by the cognate methylase when known
+                is indicated X(Y) or X,X2(Y,Y2), where X is the base within
+                the recognition sequence that is modified.  A negative number
+                indicates the complementary strand, numbered from the 5' base 
+                of that strand, and Y is the specific type of methylation 
+                involved:
+                               (6) = N6-methyladenosine 
+                               (5) = 5-methylcytosine 
+                               (4) = N4-methylcytosine
+
+                If the methylation information is different for the 3' strand,
+                X2 and Y2 are given as well.
+
+<MICROORGANISM> Organism from which this enzyme had been isolated.
+<SOURCE>        Either an individual or a National Culture Collection.
+<COMMERCIAL AVAILABILITY>
+                Each commercial source of restriction enzymes and/or methylases
+                listed in REBASE is assigned a single character abbreviation 
+                code.  For example:
+
+                K        Takara (1/98)
+                M        Boehringer Mannheim (10/97)
+                N        New England Biolabs (4/98)
+ 
+                The date in parentheses indicates the most recent update of 
+                that organization's listings in REBASE.
+
+<REFERENCES>only the primary references for the isolation and/or purification
+of the restriction enzyme or methylase, the determination of the recognition
+sequence and cleavage site or the methylation specificity are given.
+
+
+REBASE codes for commercial sources of enzymes
+
+                B        Life Technologies (3/21)
+                C        Minotech Biotechnology (3/21)
+                E        Agilent Technologies (8/20)
+                I        SibEnzyme Ltd. (3/21)
+                J        Nippon Gene Co., Ltd. (3/21)
+                K        Takara Bio Inc. (6/18)
+                M        Roche Applied Science (4/18)
+                N        New England Biolabs (3/21)
+                O        Toyobo Biochemicals (8/14)
+                Q        Molecular Biology Resources - CHIMERx (3/21)
+                R        Promega Corporation (11/20)
+                S        Sigma Chemical Corporation (3/21)
+                V        Vivantis Technologies (1/18)
+                X        EURx Ltd. (1/21)
+                Y        SinaClon BioScience Co. (1/18)
+
+<1>AaaI
+<2>XmaIII,BseX3I,BsoDI,BstZI,EagI,EclXI,Eco52I,SenPT16I,TauII,Tsp504I
+<3>C^GGCCG
+<4>
+<5>Acetobacter aceti ss aceti
+<6>M. Fukaya
+<7>
+<8>Tagami, H., Tayama, K., Tohyama, T., Fukaya, M., Okumura, H., Kawamura, Y., Horinouchi, S., Beppu, T., (1988) FEMS Microbiol. Lett., vol. 56, pp. 161-166.
+
+<1>AarI
+<2>PaqCI
+<3>CACCTGC(4/8)
+<4>
+<5>Arthrobacter aurescens SS2-322
+<6>A. Janulaitis
+<7>B
+<8>Grigaite, R., Maneliene, Z., Janulaitis, A., (2002) Nucleic Acids Res., vol. 30.
+Maneliene, Z., Zakareviciene, L., Unpublished observations.
+
+<1>AatII
+<2>AspJI,Ppu1253I,Ssp5230I,ZraI
+<3>GACGT^C
+<4>2(6)
+<5>Acetobacter aceti IFO 3281
+<6>IFO 3281
+<7>BIKMNV
+<8>Clark, T.A., Murray, I.A., Morgan, R.D., Kislyuk, A.O., Spittle, K.E., Boitano, M., Fomenkov, A., Roberts, R.J., Korlach, J., (2012) Nucleic Acids Res., vol. 40.
+Flodman, K., Xu, S.-Y., Unpublished observations.
+Fomenkov, A., Unpublished observations.
+Sugisaki, H., Maekawa, Y., Kanazawa, S., Takanami, M., (1982) Nucleic Acids Res., vol. 10, pp. 5747-5752.
+Xu, S.-Y., Nwankwo, D.O., European Patent Office, 1992.

--- a/io/rebase/rebase.go
+++ b/io/rebase/rebase.go
@@ -219,7 +219,7 @@ func Parse(file io.Reader) (map[string]Enzyme, error) {
 
 			if startCommercialParsing {				
 				// Parse the commercial availability lines and run it through the regex compiler
-				r, _ := regexp.Compile("\\s*([A-Z])\\s+(.*)\\s+\\((\\d+\\/\\d+)\\)")
+				r, _ := regexp.Compile(`\s*([A-Z])\s+(.*)\s+\((\d+\/\d+)\)`)
 				matches := r.FindStringSubmatch(line)
 
 				if matches != nil {
@@ -281,8 +281,6 @@ func Parse(file io.Reader) (map[string]Enzyme, error) {
 	if lastCodeisReferenceCode {
 		enzymeMap[enzyme.Name] = enzyme
 		enzyme = Enzyme{}
-		lastCodeisReferenceCode = false
-
 	}
 
 	return enzymeMap, err

--- a/io/rebase/rebase.go
+++ b/io/rebase/rebase.go
@@ -21,112 +21,113 @@ header with the commercial suppliers format and an example enzyme.
 ```
 REBASE version 104                                              withrefm.104
 
-    =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-    REBASE, The Restriction Enzyme Database   http://rebase.neb.com
-    Copyright (c)  Dr. Richard J. Roberts, 2021.   All rights reserved.
-    =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+	=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+	REBASE, The Restriction Enzyme Database   http://rebase.neb.com
+	Copyright (c)  Dr. Richard J. Roberts, 2021.   All rights reserved.
+	=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
-Rich Roberts                                                    Mar 31 2021
-
+# Rich Roberts                                                    Mar 31 2021
 
 <ENZYME NAME>   Restriction enzyme name.
 <ISOSCHIZOMERS> Other enzymes with this specificity.
 <RECOGNITION SEQUENCE>
-                These are written from 5' to 3', only one strand being given.
-                If the point of cleavage has been determined, the precise site
-                is marked with ^.  For enzymes such as HgaI, MboII etc., which
-                cleave away from their recognition sequence the cleavage sites
-                are indicated in parentheses.
 
-                For example HgaI GACGC (5/10) indicates cleavage as follows:
-                                5' GACGCNNNNN^      3'
-                                3' CTGCGNNNNNNNNNN^ 5'
+	These are written from 5' to 3', only one strand being given.
+	If the point of cleavage has been determined, the precise site
+	is marked with ^.  For enzymes such as HgaI, MboII etc., which
+	cleave away from their recognition sequence the cleavage sites
+	are indicated in parentheses.
 
-                In all cases the recognition sequences are oriented so that
-                the cleavage sites lie on their 3' side.
+	For example HgaI GACGC (5/10) indicates cleavage as follows:
+	                5' GACGCNNNNN^      3'
+	                3' CTGCGNNNNNNNNNN^ 5'
 
-                REBASE Recognition sequences representations use the standard
-                abbreviations (Eur. J. Biochem. 150: 1-5, 1985) to represent
-                ambiguity.
-                                R = G or A
-                                Y = C or T
-                                M = A or C
-                                K = G or T
-                                S = G or C
-                                W = A or T
-                                B = not A (C or G or T)
-                                D = not C (A or G or T)
-                                H = not G (A or C or T)
-                                V = not T (A or C or G)
-                                N = A or C or G or T
+	In all cases the recognition sequences are oriented so that
+	the cleavage sites lie on their 3' side.
 
-
-
-                ENZYMES WITH UNUSUAL CLEAVAGE PROPERTIES:
-
-                Enzymes that cut on both sides of their recognition sequences,
-                such as BcgI, Bsp24I, CjeI and CjePI, have 4 cleavage sites
-                each instead of 2.
-
-                Bsp24I
-                          5'      ^NNNNNNNNGACNNNNNNTGGNNNNNNNNNNNN^   3'
-                          3' ^NNNNNNNNNNNNNCTGNNNNNNACCNNNNNNN^        5'
+	REBASE Recognition sequences representations use the standard
+	abbreviations (Eur. J. Biochem. 150: 1-5, 1985) to represent
+	ambiguity.
+	                R = G or A
+	                Y = C or T
+	                M = A or C
+	                K = G or T
+	                S = G or C
+	                W = A or T
+	                B = not A (C or G or T)
+	                D = not C (A or G or T)
+	                H = not G (A or C or T)
+	                V = not T (A or C or G)
+	                N = A or C or G or T
 
 
-                This will be described in some REBASE reports as:
 
-                             Bsp24I (8/13)GACNNNNNNTGG(12/7)
+	ENZYMES WITH UNUSUAL CLEAVAGE PROPERTIES:
+
+	Enzymes that cut on both sides of their recognition sequences,
+	such as BcgI, Bsp24I, CjeI and CjePI, have 4 cleavage sites
+	each instead of 2.
+
+	Bsp24I
+	          5'      ^NNNNNNNNGACNNNNNNTGGNNNNNNNNNNNN^   3'
+	          3' ^NNNNNNNNNNNNNCTGNNNNNNACCNNNNNNN^        5'
+
+
+	This will be described in some REBASE reports as:
+
+	             Bsp24I (8/13)GACNNNNNNTGG(12/7)
 
 <METHYLATION SITE>
-                The site of methylation by the cognate methylase when known
-                is indicated X(Y) or X,X2(Y,Y2), where X is the base within
-                the recognition sequence that is modified.  A negative number
-                indicates the complementary strand, numbered from the 5' base
-                of that strand, and Y is the specific type of methylation
-                involved:
-                               (6) = N6-methyladenosine
-                               (5) = 5-methylcytosine
-                               (4) = N4-methylcytosine
 
-                If the methylation information is different for the 3' strand,
-                X2 and Y2 are given as well.
+	The site of methylation by the cognate methylase when known
+	is indicated X(Y) or X,X2(Y,Y2), where X is the base within
+	the recognition sequence that is modified.  A negative number
+	indicates the complementary strand, numbered from the 5' base
+	of that strand, and Y is the specific type of methylation
+	involved:
+	               (6) = N6-methyladenosine
+	               (5) = 5-methylcytosine
+	               (4) = N4-methylcytosine
+
+	If the methylation information is different for the 3' strand,
+	X2 and Y2 are given as well.
 
 <MICROORGANISM> Organism from which this enzyme had been isolated.
 <SOURCE>        Either an individual or a National Culture Collection.
 <COMMERCIAL AVAILABILITY>
-                Each commercial source of restriction enzymes and/or methylases
-                listed in REBASE is assigned a single character abbreviation
-                code.  For example:
 
-                K        Takara (1/98)
-                M        Boehringer Mannheim (10/97)
-                N        New England Biolabs (4/98)
+	Each commercial source of restriction enzymes and/or methylases
+	listed in REBASE is assigned a single character abbreviation
+	code.  For example:
 
-                The date in parentheses indicates the most recent update of
-                that organization's listings in REBASE.
+	K        Takara (1/98)
+	M        Boehringer Mannheim (10/97)
+	N        New England Biolabs (4/98)
+
+	The date in parentheses indicates the most recent update of
+	that organization's listings in REBASE.
 
 <REFERENCES>only the primary references for the isolation and/or purification
 of the restriction enzyme or methylase, the determination of the recognition
 sequence and cleavage site or the methylation specificity are given.
 
-
 REBASE codes for commercial sources of enzymes
 
-                B        Life Technologies (3/21)
-                C        Minotech Biotechnology (3/21)
-                E        Agilent Technologies (8/20)
-                I        SibEnzyme Ltd. (3/21)
-                J        Nippon Gene Co., Ltd. (3/21)
-                K        Takara Bio Inc. (6/18)
-                M        Roche Applied Science (4/18)
-                N        New England Biolabs (3/21)
-                O        Toyobo Biochemicals (8/14)
-                Q        Molecular Biology Resources - CHIMERx (3/21)
-                R        Promega Corporation (11/20)
-                S        Sigma Chemical Corporation (3/21)
-                V        Vivantis Technologies (1/18)
-                X        EURx Ltd. (1/21)
-                Y        SinaClon BioScience Co. (1/18)
+	B        Life Technologies (3/21)
+	C        Minotech Biotechnology (3/21)
+	E        Agilent Technologies (8/20)
+	I        SibEnzyme Ltd. (3/21)
+	J        Nippon Gene Co., Ltd. (3/21)
+	K        Takara Bio Inc. (6/18)
+	M        Roche Applied Science (4/18)
+	N        New England Biolabs (3/21)
+	O        Toyobo Biochemicals (8/14)
+	Q        Molecular Biology Resources - CHIMERx (3/21)
+	R        Promega Corporation (11/20)
+	S        Sigma Chemical Corporation (3/21)
+	V        Vivantis Technologies (1/18)
+	X        EURx Ltd. (1/21)
+	Y        SinaClon BioScience Co. (1/18)
 
 <1>AaaI
 <2>XmaIII,BseX3I,BsoDI,BstZI,EagI,EclXI,Eco52I,SenPT16I,TauII,Tsp504I
@@ -147,6 +148,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"unicode"
 )
 
 var (
@@ -164,7 +166,7 @@ type Enzyme struct {
 	MicroOrganism          string   `json:"microorganism"`
 	Source                 string   `json:"source"`
 	CommercialAvailability []string `json:"commercialAvailability"`
-	References             string   `json:"references"`
+	References             []string   `json:"references"`
 }
 
 // Parse parses the Rebase database into a map of enzymes
@@ -187,6 +189,12 @@ func Parse(file io.Reader) (map[string]Enzyme, error) {
 	commercialParsingLine := 0
 	startCommercialParsing := false
 	for _, line := range lines {
+		// Check if line is an empty line, this necessary since we are now checking to 
+		// see if the multi line references are still a thing
+		var strippedLine = stripWhiteSpaces(line)
+		if strippedLine == "" {
+			continue
+		}
 		// Parse commercial sources map
 		if line == "REBASE codes for commercial sources of enzymes" {
 			startCommercialParsing = true
@@ -219,34 +227,59 @@ func Parse(file io.Reader) (map[string]Enzyme, error) {
 		}
 
 		// Normal enzyme parsing
+		var lastCodeisReferenceCode = false
 		switch {
-		case strings.Contains(line, "<1>"):
-			enzyme.Name = line[3:]
-		case strings.Contains(line, "<2>"):
-			enzyme.Isoschizomers = strings.Split(line[3:], ",")
-		case strings.Contains(line, "<3>"):
-			enzyme.RecognitionSequence = line[3:]
-		case strings.Contains(line, "<4>"):
-			enzyme.MethylationSite = line[3:]
-		case strings.Contains(line, "<5>"):
-			enzyme.MicroOrganism = line[3:]
-		case strings.Contains(line, "<6>"):
-			enzyme.Source = line[3:]
-		case strings.Contains(line, "<7>"):
-			// We need to get a list of specific commercial suppliers from the commercialSupplierMap we previously made
-			var commercialSuppliers []string
-			for _, commercialLetter := range line[3:] {
-				commercialSuppliers = append(commercialSuppliers, commercialSupplierMap[commercialLetter])
-			}
-			enzyme.CommercialAvailability = commercialSuppliers
-		case strings.Contains(line, "<8>"):
-			enzyme.References = line[3:]
-			// After every <8> a new enzyme will start. So here, we put the current enzyme into the enzymeMap and setup a new enzyme to be filled
-			enzymeMap[enzyme.Name] = enzyme
-			enzyme = Enzyme{}
+			case strings.Contains(line, "<1>"):
+				if lastCodeisReferenceCode == true{
+					// After every <8> a new enzyme will start. So here, we put the current enzyme into the enzymeMap and 
+					// setup a new enzyme to be filled doing this check ensures that we compile all the multiline 
+					// references into the enzyme
+					enzymeMap[enzyme.Name] = enzyme
+					enzyme = Enzyme{}
+					lastCodeisReferenceCode = false
+				}
+				enzyme.Name = line[3:]
+			case strings.Contains(line, "<2>"):
+				enzyme.Isoschizomers = strings.Split(line[3:], ",")
+			case strings.Contains(line, "<3>"):
+				enzyme.RecognitionSequence = line[3:]
+			case strings.Contains(line, "<4>"):
+				enzyme.MethylationSite = line[3:]
+			case strings.Contains(line, "<5>"):
+				enzyme.MicroOrganism = line[3:]
+			case strings.Contains(line, "<6>"):
+				enzyme.Source = line[3:]
+			case strings.Contains(line, "<7>"):
+				// We need to get a list of specific commercial suppliers from the commercialSupplierMap we previously made
+				var commercialSuppliers []string
+				for _, commercialLetter := range line[3:] {
+					commercialSuppliers = append(commercialSuppliers, commercialSupplierMap[commercialLetter])
+				}
+				enzyme.CommercialAvailability = commercialSuppliers
+			case strings.Contains(line, "<8>"):
+				enzyme.References = append(enzyme.References, line[3:]) 
+			default:
+				// Since the references in the file are in new lines, the flag here checks to make sure that the parsing is 
+				// still conisdering this the references state
+				if lastCodeisReferenceCode == true {
+					enzyme.References = append(enzyme.References, line[3:])
+				}
 		}
 	}
 	return enzymeMap, err
+}
+
+// Helper function used to strip all whitespaces 
+// TODO: Decide if we should create a new string utils class for this
+func stripWhiteSpaces(str string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			// if the character is a space, drop it
+			return -1
+		}
+		// else keep it in the string
+		return r
+	}, str)
 }
 
 // Read returns an enzymeMap from a Rebase data dump

--- a/io/rebase/rebase_test.go
+++ b/io/rebase/rebase_test.go
@@ -3,6 +3,7 @@ package rebase
 import (
 	"errors"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -14,6 +15,25 @@ func TestRead(t *testing.T) {
 	if err == nil {
 		t.Errorf("Failed to error on fake file")
 	}
+}
+
+func TestParse(t *testing.T) {
+	file, err := os.Open("data/rebase_minimal.txt")
+	if err != nil {
+		t.Errorf("Failed to read rebase test file")
+	}
+	emzymeMap, err := parseFn(file)
+	if err != nil {
+		t.Errorf("Error parsing the file data")
+	}
+	exportedJSON, err := Export(emzymeMap)
+	if err != nil {
+		t.Errorf("Error exporing the enzyme map to JSON")
+	}
+	file2, err := os.Create("rebase_minimal.json")
+	file2.WriteString(string(exportedJSON))
+	file2.Close()
+	
 }
 
 func TestParse_error(t *testing.T) {

--- a/io/rebase/rebase_test.go
+++ b/io/rebase/rebase_test.go
@@ -37,8 +37,10 @@ func TestParse(t *testing.T) {
 
 	// we unmarshal our byteArray which contains our
 	// jsonFile's content into 'enzymes' which we defined above
-	json.Unmarshal(byteData, &benchmarkEnzymeMap)
-
+	err = json.Unmarshal(byteData, &benchmarkEnzymeMap)
+	if err != nil {
+		t.Errorf("Failed to parse rebase json file into enzyme map")
+	}
 
 	// Open the rebase file
 	rebaseFile, err := os.Open("data/rebase_minimal.txt")


### PR DESCRIPTION
Fixed the issue #278 . 

# Changelog:
- Rewrote the commercial availability section to use a RegEx based parser that makes it more resilient to malformed / mis-indented files
- Updated the basic structure to capture the availability and the dates as pair entries in the main enzyme data structure
- Cleaned up all depreciated `ioutils` references
- Added a parser test with a minimal test cases 

# Reviewer Questions
1. Do I need to add more tests for this PR ?
2. Can I get support to verify that the JSON dump I'm using is correct ?
3. Do we need to add a stress test with the large rebase test case ? How do we validate it ?
4. Is there a way to generate malformed rebase files to test for panics ?

# Recommendations for the future:
- We need to move science-related data and commercial data to separate data structures that are not clubbed together
- We need to standardize parser writing to use something like ANTLR. Logic writing and debugging will be hard to maintain in the future. 
