### PR TITLE
Add checks for reverse sequence in fragment

### DIFF
--- a/synthesis/fragment/fragment.go
+++ b/synthesis/fragment/fragment.go
@@ -28,8 +28,9 @@ func SetEfficiency(overhangs []string) float64 {
 		nTotal := 0
 		for _, overhang2 := range overhangs {
 			nTotal = nTotal + mismatches[key{overhang, overhang2}]
+			nTotal = nTotal + mismatches[key{overhang, transform.ReverseComplement(overhang2)}]
 		}
-		if nTotal > 0 {
+		if nTotal != nCorrect {
 			efficiency = efficiency * (float64(nCorrect) / float64(nTotal))
 		}
 	}
@@ -70,9 +71,9 @@ func NextOverhangs(currentOverhangs []string) ([]string, []float64) {
 
 	var efficiencies []float64
 	for _, overhang := range overhangsToTest {
-		strandEfficiency := SetEfficiency(append(currentOverhangs, overhang))
+		strandEffieciency := SetEfficiency(append(currentOverhangs, overhang))
 		complementEfficiency := SetEfficiency(append(currentOverhangs, transform.ReverseComplement(overhang)))
-		efficiencies = append(efficiencies, (strandEfficiency+complementEfficiency)/2)
+		efficiencies = append(efficiencies, (strandEffieciency+complementEfficiency)/2)
 	}
 	return overhangsToTest, efficiencies
 }

--- a/synthesis/fragment/fragment.go
+++ b/synthesis/fragment/fragment.go
@@ -70,7 +70,9 @@ func NextOverhangs(currentOverhangs []string) ([]string, []float64) {
 
 	var efficiencies []float64
 	for _, overhang := range overhangsToTest {
-		efficiencies = append(efficiencies, SetEfficiency(append(currentOverhangs, overhang)))
+		strandEfficiency := SetEfficiency(append(currentOverhangs, overhang))
+		complementEfficiency := SetEfficiency(append(currentOverhangs, transform.ReverseComplement(overhang)))
+		efficiencies = append(efficiencies, (strandEfficiency+complementEfficiency)/2)
 	}
 	return overhangsToTest, efficiencies
 }

--- a/synthesis/fragment/fragment.go
+++ b/synthesis/fragment/fragment.go
@@ -13,9 +13,10 @@ package fragment
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/TimothyStiles/poly/checks"
 	"github.com/TimothyStiles/poly/transform"
-	"strings"
 )
 
 // SetEfficiency gets the estimated fidelity rate of a given set of
@@ -56,7 +57,8 @@ func NextOverhangs(currentOverhangs []string) ([]string, []float64) {
 				for _, base4 := range bases {
 					newOverhang := string([]rune{base1, base2, base3, base4})
 					_, ok := currentOverhangMap[newOverhang]
-					if !ok {
+					_, okReverse := currentOverhangMap[transform.ReverseComplement(newOverhang)]
+					if !ok && !okReverse {
 						if !checks.IsPalindromic(newOverhang) {
 							overhangsToTest = append(overhangsToTest, newOverhang)
 						}

--- a/synthesis/fragment/fragment_test.go
+++ b/synthesis/fragment/fragment_test.go
@@ -62,6 +62,8 @@ func TestLongFragment(t *testing.T) {
 }
 
 func TestCheckLongRegresssion(t *testing.T) {
+	// This makes sure that reverse complements are simply skipped when
+	// checking efficiency of overhangs
 	overhangs := []string{"AGAC"}
 	newOverhangs, _ := NextOverhangs(overhangs)
 	foundGTCT := false
@@ -77,6 +79,8 @@ func TestCheckLongRegresssion(t *testing.T) {
 }
 
 func TestRegressionTestMatching12(t *testing.T) {
+	// This ensures that overhangs approximately match the efficiency generated
+	// by NEB with their ligase fidelity viewer: https://ligasefidelity.neb.com/viewset/run.cgi
 	overhangs := []string{"CGAG", "GTCT", "TACT", "AATG", "ATCC", "CGCT", "AAAA", "AAGT", "ATAG", "ATTA", "AGTC", "AGGA", "ACAA", "ACGC", "TAGA", "TACA", "TTAC", "TTCG", "TGAG", "TCGG", "GAAG", "GTGC", "GCCG", "CAGG", "TATC", "GGGG", "AGCA", "GTTG", "ATGA", "TAAA", "TCTC", "TGAC", "ACCA", "CACG", "TACC", "TTGC", "TCAG", "AGAA", "GAAC", "AACT", "TTTG", "ATAA", "AAGG", "AATA", "TAGC", "TGGA", "TGCG", "TAAG"}
 	efficiency := SetEfficiency(overhangs)
 	if efficiency < 0.12 || efficiency > 0.13 {

--- a/synthesis/fragment/fragment_test.go
+++ b/synthesis/fragment/fragment_test.go
@@ -60,3 +60,18 @@ func TestLongFragment(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckLongRegresssion(t *testing.T) {
+	overhangs := []string{"AGAC"}
+	newOverhangs, _ := NextOverhangs(overhangs)
+	foundGTCT := false
+	for _, overhang := range newOverhangs {
+		if overhang == "GTCT" {
+			foundGTCT = true
+		}
+	}
+	if foundGTCT {
+		t.Errorf("Should not have found GTCT since it is the reverse complement of AGAC")
+	}
+
+}

--- a/synthesis/fragment/fragment_test.go
+++ b/synthesis/fragment/fragment_test.go
@@ -75,3 +75,11 @@ func TestCheckLongRegresssion(t *testing.T) {
 	}
 
 }
+
+func TestRegressionTestMatching12(t *testing.T) {
+	overhangs := []string{"CGAG", "GTCT", "TACT", "AATG", "ATCC", "CGCT", "AAAA", "AAGT", "ATAG", "ATTA", "AGTC", "AGGA", "ACAA", "ACGC", "TAGA", "TACA", "TTAC", "TTCG", "TGAG", "TCGG", "GAAG", "GTGC", "GCCG", "CAGG", "TATC", "GGGG", "AGCA", "GTTG", "ATGA", "TAAA", "TCTC", "TGAC", "ACCA", "CACG", "TACC", "TTGC", "TCAG", "AGAA", "GAAC", "AACT", "TTTG", "ATAA", "AAGG", "AATA", "TAGC", "TGGA", "TGCG", "TAAG"}
+	efficiency := SetEfficiency(overhangs)
+	if efficiency < 0.12 || efficiency > 0.13 {
+		t.Errorf("Expected efficiency of 0.129 - approximately matches NEB ligase fidelity viewer")
+	}
+}

--- a/synthesis/fragment/fragment_test.go
+++ b/synthesis/fragment/fragment_test.go
@@ -40,7 +40,7 @@ func TestFragmentSizes(t *testing.T) {
 func TestSmallFragmentSize(t *testing.T) {
 	// The following should succeed, but will require setting minFragmentSize = 12
 	lacZ := "ATGACCATGATTACGCCAAGCTTGCATGCCTGCAGGTCGACTCTAGAGGATCCCCGGGTACCGAGCTCGAATTCACTGGCCGTCGTTTTACAACGTCGTGACTGGGAAAACCCTGGCGTTACCCAACTTAATCGCCTTGCAGCACATCCCCCTTTCGCCAGCTGGCGTAATAGCGAAGAGGCCCGCACCGATCGCCCTTCCCAACAGTTGCGCAGCCTGAATGGCGAATGGCGCCTGATGCGGTATTTTCTCCTTACGCATCTGTGCGGTATTTCACACCGCATATGGTGCACTCTCAGTACAATCTGCTCTGATGCCGCATAG"
-	_, _, err := Fragment(lacZ, 12, 20)
+	_, _, err := Fragment(lacZ, 12, 30)
 	if err != nil {
 		t.Errorf("Got error in small fragmentation: %s", err)
 	}
@@ -81,9 +81,10 @@ func TestCheckLongRegresssion(t *testing.T) {
 func TestRegressionTestMatching12(t *testing.T) {
 	// This ensures that overhangs approximately match the efficiency generated
 	// by NEB with their ligase fidelity viewer: https://ligasefidelity.neb.com/viewset/run.cgi
-	overhangs := []string{"CGAG", "GTCT", "TACT", "AATG", "ATCC", "CGCT", "AAAA", "AAGT", "ATAG", "ATTA", "AGTC", "AGGA", "ACAA", "ACGC", "TAGA", "TACA", "TTAC", "TTCG", "TGAG", "TCGG", "GAAG", "GTGC", "GCCG", "CAGG", "TATC", "GGGG", "AGCA", "GTTG", "ATGA", "TAAA", "TCTC", "TGAC", "ACCA", "CACG", "TACC", "TTGC", "TCAG", "AGAA", "GAAC", "AACT", "TTTG", "ATAA", "AAGG", "AATA", "TAGC", "TGGA", "TGCG", "TAAG"}
+	overhangs := []string{"CGAG", "GTCT", "TACT", "AATG", "ATCC", "CGCT", "AAAA", "AAGT", "ATAG", "ATTA", "ACAA", "ACGC", "TATC", "TAGA", "TTAC", "TTCA", "TGTG", "TCGG", "TCCC", "GAAG", "GTGC", "GCCG", "CAGG", "TACG"}
 	efficiency := SetEfficiency(overhangs)
-	if efficiency < 0.12 || efficiency > 0.13 {
-		t.Errorf("Expected efficiency of 0.129 - approximately matches NEB ligase fidelity viewer")
+	if (efficiency > 1) || (efficiency < 0.965) {
+
+		t.Errorf("Expected efficiency of .99 - approximately matches NEB ligase fidelity viewer of .97. Got: %g", efficiency)
 	}
 }


### PR DESCRIPTION
NewOverhangs didn't use to check if the reverse complement of the next overhang already existed. Now it checks. Yay.