### PR TITLE
add parser.line++ so error messages make sense

### DIFF
--- a/io/slow5/slow5.go
+++ b/io/slow5/slow5.go
@@ -202,6 +202,7 @@ func (parser *Parser) ParseNext() (Read, error) {
 	if err != nil {
 		return Read{}, err
 	}
+	parser.line++
 	line := strings.TrimSpace(string(lineBytes))
 
 	values := strings.Split(string(line), "\t")


### PR DESCRIPTION
Stupid simple addition. parser.line wasn't iterating in slow5 parser, so error messages would be a bit non-nonsensical. Fixed this with 1 line addition.

Ready for merge.