### PR TITLE
Changed Build to use an io.Writer

### DIFF
--- a/io/fasta/example_test.go
+++ b/io/fasta/example_test.go
@@ -40,8 +40,9 @@ func ExampleParse() {
 // ExampleBuild shows basic usage for Build
 func ExampleBuild() {
 	fastas, _ := fasta.Read("data/base.fasta") // get example data
-	fasta, _ := fasta.Build(fastas)            // build a fasta byte array
-	firstLine := string(bytes.Split(fasta, []byte("\n"))[0])
+	var buffer bytes.Buffer                    // Initialize a buffer to write fastas into
+	_ = fasta.Build(fastas, &buffer)           // build a fasta byte array
+	firstLine := string(bytes.Split(buffer.Bytes(), []byte("\n"))[0])
 
 	fmt.Println(firstLine)
 	// Output: >gi|5524211|gb|AAD44166.1| cytochrome b [Elephas maximus maximus]

--- a/io/fasta/fasta_test.go
+++ b/io/fasta/fasta_test.go
@@ -120,8 +120,8 @@ func TestRead_error(t *testing.T) {
 func TestWrite_error(t *testing.T) {
 	buildErr := errors.New("build error")
 	oldBuildFn := buildFn
-	buildFn = func(fastas []Fasta) ([]byte, error) {
-		return nil, buildErr
+	buildFn = func(fastas []Fasta, w io.Writer) error {
+		return buildErr
 	}
 	defer func() {
 		buildFn = oldBuildFn

--- a/io/fastq/fastq.go
+++ b/io/fastq/fastq.go
@@ -13,7 +13,6 @@ package fastq
 
 import (
 	"bufio"
-	"bytes"
 	"compress/gzip"
 	"errors"
 	"fmt"
@@ -258,32 +257,70 @@ Start of  Write functions
 ******************************************************************************/
 
 // Build converts a Fastqs array into a byte array to be written to a file.
-func Build(fastqs []Fastq) ([]byte, error) {
-	var fastqString bytes.Buffer
+func Build(fastqs []Fastq, w io.Writer) error {
+	var err error
 	for _, fastq := range fastqs {
-		fastqString.WriteString("@")
-		fastqString.WriteString(fastq.Identifier)
-		for key, val := range fastq.Optionals {
-			fastqString.WriteString(" ")
-			fastqString.WriteString(key)
-			fastqString.WriteString("=")
-			fastqString.WriteString(val)
+		_, err = w.Write([]byte("@"))
+		if err != nil {
+			return err
 		}
-		fastqString.WriteString("\n")
+		_, err = w.Write([]byte(fastq.Identifier))
+		if err != nil {
+			return err
+		}
+		for key, val := range fastq.Optionals {
+			_, err = w.Write([]byte(" "))
+			if err != nil {
+				return err
+			}
+			_, err = w.Write([]byte(key))
+			if err != nil {
+				return err
+			}
+			_, err = w.Write([]byte("="))
+			if err != nil {
+				return err
+			}
+			_, err = w.Write([]byte(val))
+			if err != nil {
+				return err
+			}
+		}
+		_, err = w.Write([]byte("\n"))
+		if err != nil {
+			return err
+		}
 
 		// fastq doesn't limit at 80 characters, since it is
 		// mainly reading big ole' sequencing files without
 		// human input.
-		fastqString.WriteString(fastq.Sequence)
-		fastqString.WriteString("\n+\n")
-		fastqString.WriteString(fastq.Quality)
-		fastqString.WriteString("\n")
+		_, err = w.Write([]byte(fastq.Sequence))
+		if err != nil {
+			return err
+		}
+		_, err = w.Write([]byte("\n+\n"))
+		if err != nil {
+			return err
+		}
+		_, err = w.Write([]byte(fastq.Quality))
+		if err != nil {
+			return err
+		}
+		_, err = w.Write([]byte("\n"))
+		if err != nil {
+			return err
+		}
 	}
-	return fastqString.Bytes(), nil
+	return nil
 }
 
 // Write writes a fastq array to a file.
 func Write(fastqs []Fastq, path string) error {
-	fastqBytes, _ := buildFn(fastqs) //  fastq.Build returns only nil errors.
-	return os.WriteFile(path, fastqBytes, 0644)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return buildFn(fastqs, file)
 }


### PR DESCRIPTION
It was annoying me that fasta and fastq output to `[]byte` and not an io.Writer. The io.Writer interface gives you access to a lot more - you can output over a websocket, to stdout, or to a file, without having to put the entire file into memory every time.

I would like to get comments on the error checking though - it is a little annoying, since every write technically can fail (like if the output location is cut off). I could just build everything into a huge Sprintf. The way I currently implement is naive and just uses a whole bunch of errs.