### PR TITLE
Update issue templates and disable blank issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,36 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Is something broken? Create a bug report to help us improve `poly`! No issue is too small :)
 title: ''
-labels: ''
+labels: ['needs-triage', 'bug']
 assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Describe the bug
+*A clear and concise description of the bug.*
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+### Severity of the bug
+*Does this block you from working on something important? Is it a small 
+annoyance you'd like us to fix? No bug is too small, but we do have
+limited capacity and will prioritize more severe bugs!*
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+### Steps to reproduce
+*Steps to reproduce the behavior:*
+1. Build this input: '...'
+2. Run this function: '...'
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+### Expected behavior
+*A clear and concise description of what you expected to happen.*
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+### Screenshots
+*If applicable, add screenshots to help explain your problem.*
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+## Context
+*Add any other context about the problem here.*
 
-**Additional context**
-Add any other context about the problem here.
+### Client information
+*This is very important, so please fill it out!*
+ - OS: [e.g. `Fedora 36`, `Ubuntu 22.04`, `Windows 11`, etc.]
+ - Golang version: [e.g. `1.21`]
+ - `poly` version [e.g. `v0.23`]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,23 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Do you wish poly had a specific feature? Do you have ideas for improvements to the current API? Do you feel like documentation for a feature needs expansion? Big or small, we appreciate your feedback!
 title: ''
-labels: ''
+labels: ['needs-triage', 'enhancement']
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Describe the desired feature/enhancement
+*A clear and concise description of what you want to happen.*
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+### Is your feature request related to a problem?
+*A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]*
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+### Describe the solution you'd like
+*A clear and concise description of what you want to happen.*
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+### Describe alternatives you've considered (optional)
+*A clear and concise description of any alternative solutions or features you've considered.*
+
+## Additional context
+*Add any other context or screenshots about the feature request here.*


### PR DESCRIPTION
Part of #346 .

Cleaned up the issue templates to make them look nicer and be more applicable to our needs.

The more controversial part is disabling blank issues - I know @Koeng101 had said that he and Tim would likely not use issue templates, but I think that this will provide a greater incentive for people to fill out issues with more complete information that will help us triage and provide a fix. There's still always the option of deleting all the text in the template, anyway :wink: 