### PR TITLE
Allow non-contributors to take an issue with .take

### DIFF
--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -1,0 +1,19 @@
+# .github/workflows/take.yml 
+name: Assign issue to contributor
+on: 
+  issue_comment:
+    types: [created, edited] // action runs on new and edited issue comments
+
+jobs:
+  assign:
+    name: Take an issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+    - name: take the issue
+      uses: bdougie/take-action@main
+      with:
+        message: Thanks for taking this issue! Let us know if you have any questions!
+        trigger: .take
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes in this PR
Adds a GitHub action that allows non-contributors to self-assign issues when they include ".take" in an issue comment.

### Why are you making these changes?
Allows for non-contributors to indicate they are working on an issue. Part of #346 .

### Are any changes breaking? (IMPORTANT)
No.

## Pre-merge checklist
*All of these must be satisfied before this PR is considered
ready for merging. Mergeable PRs will be prioritized for review.*

* [x] New packages/exported functions have docstrings.
* [x] New/changed functionality is thoroughly tested.
* [x] New/changed functionality has a function giving an example of its usage in the associated test file. See `primers/primers_test.go` for what this might look like.
* [x] Changes are documented in `CHANGELOG.md` in the `[Unreleased]` section.
* [x] All code is properly formatted and linted.
* [x] The PR template is filled out.
