### PR TITLE
Fix PCR bug (issue #279).

### DIFF
--- a/primers/pcr/pcr.go
+++ b/primers/pcr/pcr.go
@@ -178,7 +178,7 @@ func Simulate(sequences []string, targetTm float64, circular bool, primerList []
 
 func generatePcrFragments(sequence string, forwardLocation int, reverseLocation int, forwardPrimerIndxs []int, reversePrimerIndxs []int, minimalPrimers []string, primerList []string) []string {
 	var pcrFragments []string
-	for forwardPrimerIndex := range forwardPrimerIndxs {
+	for _, forwardPrimerIndex := range forwardPrimerIndxs {
 		minimalPrimer := minimalPrimers[forwardPrimerIndex]
 		fullPrimerForward := primerList[forwardPrimerIndex]
 		for _, reversePrimerIndex := range reversePrimerIndxs {

--- a/primers/pcr/pcr_test.go
+++ b/primers/pcr/pcr_test.go
@@ -2,6 +2,8 @@ package pcr
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // gene is a gene for testing PCR
@@ -70,5 +72,20 @@ func TestSimulateConcatemerization(t *testing.T) {
 	_, err := Simulate([]string{gene}, 55.0, false, []string{forwardPrimer, reversePrimer})
 	if err == nil {
 		t.Errorf("Should have gotten concatemerization")
+	}
+}
+
+// Test to catch bug discovered by @Koeng101, see issue #279.
+func TestIssue279PCRBug(t *testing.T) {
+	gene := "aataattacaccgagataacacatcatggataaaccgatactcaaagattctatgaagctatttgaggcacttggtacgatcaagtcgcgctcaatgtttggtggcttcggacttttcgctgatgaaacgatgtttgcactggttgtgaatgatcaacttcacatacgagcagaccagcaaacttcatctaacttcgagaagcaagggctaaaaccgtacgtttataaaaagcgtggttttccagtcgttactaagtactacgcgatttccgacgacttgtgggaatccagtgaacgcttgatagaagtagcgaagaagtcgttagaacaagccaatttggaaaaaaagcaacaggcaagtagtaagcccgacaggttgaaagacctgcctaacttacgactagcgactgaacgaatgcttaagaaagctggtataaaatcagttgaacaacttgaagagaaaggtgcattgaatgcttacaaagcgatacgtgactctcactccgcaaaagtaagtattgagctactctgggctttagaaggagcgataaacggcacgcactggagcgtcgttcctcaatctcgcagagaagagctggaaaatgcgctttcttaa"
+
+	fragments, err := Simulate([]string{gene}, 55.0, false, []string{"TATATGGTCTCTTCATTTAAGAAAGCGCATTTTCCAGC", "TTATAGGTCTCATACTAATAATTACACCGAGATAACACATCATGG", "CTGCAGGTCGACTCTAG"})
+	if err != nil {
+		t.Fatalf("unexpected error during PCR simulation: %v", err)
+	}
+
+	want := "TTATAGGTCTCATACTAATAATTACACCGAGATAACACATCATGGATAAACCGATACTCAAAGATTCTATGAAGCTATTTGAGGCACTTGGTACGATCAAGTCGCGCTCAATGTTTGGTGGCTTCGGACTTTTCGCTGATGAAACGATGTTTGCACTGGTTGTGAATGATCAACTTCACATACGAGCAGACCAGCAAACTTCATCTAACTTCGAGAAGCAAGGGCTAAAACCGTACGTTTATAAAAAGCGTGGTTTTCCAGTCGTTACTAAGTACTACGCGATTTCCGACGACTTGTGGGAATCCAGTGAACGCTTGATAGAAGTAGCGAAGAAGTCGTTAGAACAAGCCAATTTGGAAAAAAAGCAACAGGCAAGTAGTAAGCCCGACAGGTTGAAAGACCTGCCTAACTTACGACTAGCGACTGAACGAATGCTTAAGAAAGCTGGTATAAAATCAGTTGAACAACTTGAAGAGAAAGGTGCATTGAATGCTTACAAAGCGATACGTGACTCTCACTCCGCAAAAGTAAGTATTGAGCTACTCTGGGCTTTAGAAGGAGCGATAAACGGCACGCACTGGAGCGTCGTTCCTCAATCTCGCAGAGAAGAGCTGGAAAATGCGCTTTCTTAAATGAAGAGACCATATA"
+	if diff := cmp.Diff(fragments[0], want); diff != "" {
+		t.Errorf("incorrect PCR output (-want,+got): %s", diff)
 	}
 }


### PR DESCRIPTION
## Changes in this PR
In `generatePcrFragments()`, there was a loop that was erroneously iterating over the indices of `forwardPrimerIndxs` rather than the values of the slice itself.

### Why are you making these changes?
Fixes #279 .

### Are any changes breaking? (IMPORTANT)
No.

## Pre-merge checklist
*All of these must be satisfied before this PR is considered
ready for merging. Mergeable PRs will be prioritized for review.*

* [x] New packages/exported functions have docstrings.
* [x] New/changed functionality is thoroughly tested.
* [x] New/changed functionality has a function giving an example of its usage in the associated test file. See `primers/primers_test.go` for what this might look like.
* [x] Changes are documented in `CHANGELOG.md` in the `[Unreleased]` section.
* [x] All code is properly formatted and linted.
* [x] The PR template is filled out.
