### PR TITLE
Fix YAML syntax error in take.yml

### DIFF
--- a/.github/workflows/take.yml
+++ b/.github/workflows/take.yml
@@ -1,8 +1,7 @@
-# .github/workflows/take.yml 
 name: Assign issue to contributor
 on: 
   issue_comment:
-    types: [created, edited] // action runs on new and edited issue comments
+    types: [created, edited] # action runs on new and edited issue comments
 
 jobs:
   assign:


### PR DESCRIPTION
## Changes in this PR
Fix a YAML syntax error in the take.yml GitHub Action, changing `//` to `#` to properly mark a comment.

### Why are you making these changes?
GitHub Action is currently broken due to this syntax error.

### Are any changes breaking? (IMPORTANT)
No.

## Pre-merge checklist
*All of these must be satisfied before this PR is considered
ready for merging. Mergeable PRs will be prioritized for review.*

* [x] New packages/exported functions have docstrings.
* [x] New/changed functionality is thoroughly tested.
* [x] New/changed functionality has a function giving an example of its usage in the associated test file. See `primers/primers_test.go` for what this might look like.
* [x] Changes are documented in `CHANGELOG.md` in the `[Unreleased]` section.
* [x] All code is properly formatted and linted.
* [x] The PR template is filled out.
