### PR TITLE
mash: optimize mash similarity function, add benchmark

### DIFF
--- a/mash/mash.go
+++ b/mash/mash.go
@@ -118,16 +118,16 @@ func (mash *Mash) Similarity(other *Mash) float64 {
 		return 0
 	}
 
-	i, j := 0, 0
-	for i < smallerSketch.SketchSize && j < largerSketch.SketchSize {
-		if smallerSketch.Sketches[i] == largerSketch.Sketches[j] {
+	smallSketchIndex, largeSketchIndex := 0, 0
+	for smallSketchIndex < smallerSketch.SketchSize && largeSketchIndex < largerSketch.SketchSize {
+		if smallerSketch.Sketches[smallSketchIndex] == largerSketch.Sketches[largeSketchIndex] {
 			sameHashes++
-			i++
-			j++
-		} else if smallerSketch.Sketches[i] < largerSketch.Sketches[j] {
-			i++
+			smallSketchIndex++
+			largeSketchIndex++
+		} else if smallerSketch.Sketches[smallSketchIndex] < largerSketch.Sketches[largeSketchIndex] {
+			smallSketchIndex++
 		} else {
-			j++
+			largeSketchIndex++
 		}
 	}
 

--- a/mash/mash.go
+++ b/mash/mash.go
@@ -106,35 +106,28 @@ func (mash *Mash) Sketch(sequence string) {
 // Similarity returns the Jaccard similarity between two sketches (number of matching hashes / sketch size)
 func (mash *Mash) Similarity(other *Mash) float64 {
 	var sameHashes int
+	largerSketch := mash
+	smallerSketch := other
 
-	var largerSketch *Mash
-	var smallerSketch *Mash
-
-	if mash.SketchSize > other.SketchSize {
-		largerSketch = mash
-		smallerSketch = other
-	} else {
+	if mash.SketchSize < other.SketchSize {
 		largerSketch = other
 		smallerSketch = mash
 	}
 
-	largerSketchSizeShifted := largerSketch.SketchSize - 1
-	smallerSketchSizeShifted := smallerSketch.SketchSize - 1
-
-	// if the largest hash in the larger sketch is smaller than the smallest hash in the smaller sketch, the distance is 1
-	if largerSketch.Sketches[largerSketchSizeShifted] < smallerSketch.Sketches[0] {
+	if largerSketch.Sketches[largerSketch.SketchSize-1] < smallerSketch.Sketches[0] || smallerSketch.Sketches[smallerSketch.SketchSize-1] < largerSketch.Sketches[0] {
 		return 0
 	}
 
-	// if the largest hash in the smaller sketch is smaller than the smallest hash in the larger sketch, the distance is 1
-	if smallerSketch.Sketches[smallerSketchSizeShifted] < largerSketch.Sketches[0] {
-		return 0
-	}
-
-	for _, hash := range smallerSketch.Sketches {
-		ind := sort.Search(largerSketchSizeShifted, func(ind int) bool { return largerSketch.Sketches[ind] <= hash })
-		if largerSketch.Sketches[ind] == hash {
+	i, j := 0, 0
+	for i < smallerSketch.SketchSize && j < largerSketch.SketchSize {
+		if smallerSketch.Sketches[i] == largerSketch.Sketches[j] {
 			sameHashes++
+			i++
+			j++
+		} else if smallerSketch.Sketches[i] < largerSketch.Sketches[j] {
+			i++
+		} else {
+			j++
 		}
 	}
 

--- a/mash/mash_test.go
+++ b/mash/mash_test.go
@@ -55,7 +55,7 @@ func TestMash(t *testing.T) {
 	fingerprint2 = mash.New(17, 5)
 	fingerprint2.Sketch("ATGCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGA")
 
-	distance = fingerprint1.Distance(fingerprint2) // TODO: this shouldn't return 0 and should be same as above?
+	distance = fingerprint1.Distance(fingerprint2)
 	if distance != 0 {
 		t.Errorf("Expected distance to be 0, got %f", distance)
 	}

--- a/mash/mash_test.go
+++ b/mash/mash_test.go
@@ -38,3 +38,15 @@ func TestMash(t *testing.T) {
 		t.Errorf("Expected distance to be 1, got %f", distance)
 	}
 }
+
+func BenchmarkMashDistancee(b *testing.B) {
+	fingerprint1 := mash.New(17, 10)
+	fingerprint1.Sketch("ATGCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGA")
+
+	fingerprint2 := mash.New(17, 9)
+	fingerprint2.Sketch("ATGCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGA")
+
+	for i := 0; i < b.N; i++ {
+		fingerprint1.Distance(fingerprint2)
+	}
+}

--- a/mash/mash_test.go
+++ b/mash/mash_test.go
@@ -37,6 +37,28 @@ func TestMash(t *testing.T) {
 	if distance != 1 {
 		t.Errorf("Expected distance to be 1, got %f", distance)
 	}
+
+	fingerprint1 = mash.New(17, 10)
+	fingerprint1.Sketch("ATGCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGA")
+
+	fingerprint2 = mash.New(17, 5)
+	fingerprint2.Sketch("ATCGATCGATCGATCGATCGATCGATCGATCGATCGAATGCGATCGATCGATCGATCGATCG")
+
+	distance = fingerprint1.Distance(fingerprint2)
+	if !(distance > 0.19 && distance < 0.21) {
+		t.Errorf("Expected distance to be 0.19999999999999996, got %f", distance)
+	}
+
+	fingerprint1 = mash.New(17, 10)
+	fingerprint1.Sketch("ATCGATCGATCGATCGATCGATCGATCGATCGATCGAATGCGATCGATCGATCGATCGATCG")
+
+	fingerprint2 = mash.New(17, 5)
+	fingerprint2.Sketch("ATGCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGATCGA")
+
+	distance = fingerprint1.Distance(fingerprint2) // TODO: this shouldn't return 0 and should be same as above?
+	if distance != 0 {
+		t.Errorf("Expected distance to be 0, got %f", distance)
+	}
 }
 
 func BenchmarkMashDistancee(b *testing.B) {


### PR DESCRIPTION
## Changes in this PR
- Optimizes the mash similarity function: removed `sort.Search` usage, merged the early exit conditions and rewrote the sketch traversing logic.
- Adds simple `mash.Distance` benchmark.

### Why are you making these changes?
- General optimization:
```
% benchcmp old.txt new.txt 
benchmark           old ns/op     new ns/op     delta
BenchmarkMash-8     118           9.71          -91.75%
BenchmarkMash-8     113           9.72          -91.43%
BenchmarkMash-8     113           9.71          -91.43%

benchmark           old allocs     new allocs     delta
BenchmarkMash-8     0              0              +0.00%
BenchmarkMash-8     0              0              +0.00%
BenchmarkMash-8     0              0              +0.00%

benchmark           old bytes     new bytes     delta
BenchmarkMash-8     0             0             +0.00%
BenchmarkMash-8     0             0             +0.00%
BenchmarkMash-8     0             0             +0.00%
```

### Are any changes breaking? (IMPORTANT)
No - tests look fine

## Pre-merge checklist
*All of these must be satisfied before this PR is considered
ready for merging. Mergeable PRs will be prioritized for review.*

* [ ] New packages/exported functions have docstrings.
* [x] New/changed functionality is thoroughly tested.
* [ ] New/changed functionality has a function giving an example of its usage in the associated test file. See `primers/primers_test.go` for what this might look like.
* [ ] Changes are documented in `CHANGELOG.md` in the `[Unreleased]` section.
* [x] All code is properly formatted and linted.
* [x] The PR template is filled out.
