### PR TITLE
Improve Hash2Fragment by using a map to validate allowed sequence characters

### DIFF
--- a/seqhash/seqhash.go
+++ b/seqhash/seqhash.go
@@ -103,6 +103,9 @@ const (
 	FRAGMENT SequenceType = "FRAGMENT"
 )
 
+// allowedChars holds a map of allowed characters for DNA/RNA, used by Hash2Fragment:
+var allowedChars = map[rune]bool{'A': true, 'T': true, 'U': true, 'G': true, 'C': true, 'Y': true, 'R': true, 'S': true, 'W': true, 'K': true, 'M': true, 'B': true, 'D': true, 'H': true, 'V': true, 'N': true, 'Z': true}
+
 // boothLeastRotation gets the least rotation of a circular string.
 func boothLeastRotation(sequence string) int {
 	// https://en.wikipedia.org/wiki/Lexicographically_minimal_string_rotation
@@ -385,7 +388,7 @@ func Hash2Fragment(sequence string, fwdOverhangLength uint8, revOverhangLength u
 
 	// First, run checks and get the determistic sequence of the hash
 	for _, char := range sequence {
-		if !strings.Contains("ATUGCYRSWKMBDHVNZ", string(char)) {
+		if !allowedChars[char] {
 			return result, errors.New("Only letters ATUGCYRSWKMBDHVNZ are allowed for DNA/RNA. Got letter: " + string(char))
 		}
 	}


### PR DESCRIPTION
## Changes in this PR
- Improves `Hash2Fragment` by using a map for more efficient validation of allowed sequence characters, discussion [here](https://github.com/TimothyStiles/poly/pull/398#discussion_r1393602404).

### Why are you making these changes?
General improvement.

### Are any changes breaking? (IMPORTANT)
No

## Pre-merge checklist
*All of these must be satisfied before this PR is considered
ready for merging. Mergeable PRs will be prioritized for review.*

* [ ] New packages/exported functions have docstrings.
* [x] New/changed functionality is thoroughly tested.
* [ ] New/changed functionality has a function giving an example of its usage in the associated test file. See `primers/primers_test.go` for what this might look like.
* [ ] Changes are documented in `CHANGELOG.md` in the `[Unreleased]` section.
* [x] All code is properly formatted and linted.
* [x] The PR template is filled out.
