### PR TITLE
Separated minimums between design and simulate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+ - Made it possible to simulate primers shorter than design minimum.
+
 ## [0.31.1] - 2024-01-31
 
 ### Added

--- a/primers/pcr/pcr.go
+++ b/primers/pcr/pcr.go
@@ -32,7 +32,10 @@ import (
 )
 
 // https://doi.org/10.1089/dna.1994.13.75
-var minimalPrimerLength int = 15
+var minimalPrimerLength int = 7
+
+// what we want for designs
+var designedMinimalPrimerLength int = 15
 
 // DesignPrimersWithOverhangs designs two primers to amplify a target sequence,
 // adding on an overhang to the forward and reverse strand. This overhang can
@@ -40,13 +43,13 @@ var minimalPrimerLength int = 15
 // or GoldenGate restriction enzyme sites.
 func DesignPrimersWithOverhangs(sequence, forwardOverhang, reverseOverhang string, targetTm float64) (string, string) {
 	sequence = strings.ToUpper(sequence)
-	forwardPrimer := sequence[0:minimalPrimerLength]
+	forwardPrimer := sequence[0:designedMinimalPrimerLength]
 	for additionalNucleotides := 0; primers.MeltingTemp(forwardPrimer) < targetTm; additionalNucleotides++ {
-		forwardPrimer = sequence[0 : minimalPrimerLength+additionalNucleotides]
+		forwardPrimer = sequence[0 : designedMinimalPrimerLength+additionalNucleotides]
 	}
-	reversePrimer := transform.ReverseComplement(sequence[len(sequence)-minimalPrimerLength:])
+	reversePrimer := transform.ReverseComplement(sequence[len(sequence)-designedMinimalPrimerLength:])
 	for additionalNucleotides := 0; primers.MeltingTemp(reversePrimer) < targetTm; additionalNucleotides++ {
-		reversePrimer = transform.ReverseComplement(sequence[len(sequence)-(minimalPrimerLength+additionalNucleotides):])
+		reversePrimer = transform.ReverseComplement(sequence[len(sequence)-(designedMinimalPrimerLength+additionalNucleotides):])
 	}
 
 	// Add overhangs to primer

--- a/primers/pcr/pcr.go
+++ b/primers/pcr/pcr.go
@@ -32,10 +32,10 @@ import (
 )
 
 // https://doi.org/10.1089/dna.1994.13.75
-var minimalPrimerLength int = 7
+const minimalPrimerLength int = 7
 
 // what we want for designs
-var designedMinimalPrimerLength int = 15
+const designedMinimalPrimerLength int = 15
 
 // DesignPrimersWithOverhangs designs two primers to amplify a target sequence,
 // adding on an overhang to the forward and reverse strand. This overhang can
@@ -171,6 +171,12 @@ func SimulateSimple(sequences []string, targetTm float64, circular bool, primerL
 // in your reaction, which can lead to confusing results. The variable
 // `circular` is for if the target template is circular, like a plasmid.
 func Simulate(sequences []string, targetTm float64, circular bool, primerList []string) ([]string, error) {
+	// make sure no primers are too short
+	for _, primer := range primerList {
+		if len(primer) < minimalPrimerLength {
+			return nil, errors.New("Primers are too short.")
+		}
+	}
 	initialAmplification := SimulateSimple(sequences, targetTm, circular, primerList)
 	subsequentAmplification := SimulateSimple(sequences, targetTm, circular, append(primerList, initialAmplification...))
 	if len(initialAmplification) != len(subsequentAmplification) {


### PR DESCRIPTION
## Changes in this PR

The minimum primer length is set at 15, which is probably reasonable for designing new primers but is too restrictive for simulating given primers. The cited reference in code comment supports using 7, instead of 15. 


This changes there to be a minimum for design (15, as existing code uses) and for simulate (7, as cited in paper). I also added an error for passing in short primers.

### Why are you making these changes?
I would like to use simulate to test my own primers, but index errors are thrown if I use primers smaller than minimalPrimerLength

### Are any changes breaking? (IMPORTANT)
The design code is unchanged. The simulate behavior changes because if someone simulated with short primers, the code would previously blow up with index error.

## Pre-merge checklist
*All of these must be satisfied before this PR is considered
ready for merging. Mergeable PRs will be prioritized for review.*

I actually do not see what linter is used (I've not written Go code before) - so please let me know what is appropriate here! Thanks!

* [x] New packages/exported functions have docstrings.
* [x] New/changed functionality is thoroughly tested.
* [x] New/changed functionality has a function giving an example of its usage in the associated test file. See `primers/primers_test.go` for what this might look like.
* [x] Changes are documented in `CHANGELOG.md` in the `[Unreleased]` section.
* [ ] All code is properly formatted and linted.
* [x] The PR template is filled out.
